### PR TITLE
Ignore UTRs when filtering de-novo library

### DIFF
--- a/lib/perl/Bio/EnsEMBL/EGPipeline/PipeConfig/RepeatModeler_conf.pm
+++ b/lib/perl/Bio/EnsEMBL/EGPipeline/PipeConfig/RepeatModeler_conf.pm
@@ -397,6 +397,7 @@ sub pipeline_analyses {
       {
         transcriptome_file      => '#transcripts_fasta#',
         overwrite       => 1,
+        remove_utrs     => 1, # models with repeats in UTRs are valid, so ignore UTRs when filtering
       },
       -rc_name           => 'normal',
     },


### PR DESCRIPTION
Making filtration stage less strict.
We should avoid removing repeats from library, when it overlaps an UTR.
Models with repeats in UTR are valid most of the time.