### PR TITLE
Mbarba/rnaseq

### DIFF
--- a/lib/perl/Bio/EnsEMBL/EGPipeline/BRC4Aligner/AggregateMetadata.pm
+++ b/lib/perl/Bio/EnsEMBL/EGPipeline/BRC4Aligner/AggregateMetadata.pm
@@ -47,7 +47,7 @@ sub run {
   if ($force_metadata) {
     $consensus_metadata = $force_metadata;
   } else {
-    my $all_metadata = $self->param('aligner_metadata_array');
+    my $all_metadata = $self->param('aligner_metadata_hash');
     $consensus_metadata = $self->create_consensus_metadata($all_metadata);
   }
 
@@ -75,7 +75,7 @@ sub check_metadata {
 }
   
 sub create_consensus_metadata {
-  my ($self, $metadata_array) = @_;
+  my ($self, $metadata_hash) = @_;
 
   my %met_counts = (
     "is_paired" => {},
@@ -84,7 +84,8 @@ sub create_consensus_metadata {
     "strandness" => {}
   );
   
-  for my $met (@$metadata_array) {
+  for my $sample (keys %$metadata_hash) {
+    my $met = $metadata_hash->{$sample};
     for my $key (keys %$met) {
       my $value = $met->{$key};
       $met_counts{$key}{$value}++;
@@ -111,7 +112,9 @@ sub create_consensus_metadata {
   if (@errors) {
     my $cons_str = encode_json(\%consensus);
     $cons_str =~ s/:/ => /g;
-    die("Could not create a consensus: " . join("; ", @errors) . "\nPlease check the logs and fix the Current Consensus (and copy it as 'force_metadata' param for this job):\n" . $cons_str);
+    
+    my $all_met_str = encode_json($metadata_hash);
+    die("Could not create a consensus: " . join("; ", @errors) . "\nPlease check the logs and fix the Current Consensus (and copy it as 'force_metadata' param for this job):\n" . $cons_str . "\nAll metadata: " . $all_met_str);
   }
 
   return \%consensus;

--- a/lib/perl/Bio/EnsEMBL/EGPipeline/BRC4Aligner/AggregateMetadata.pm
+++ b/lib/perl/Bio/EnsEMBL/EGPipeline/BRC4Aligner/AggregateMetadata.pm
@@ -98,13 +98,13 @@ sub create_consensus_metadata {
     my @sub_keys = keys %{$met_counts{$key}};
     @sub_keys = grep { $_ ne "" } @sub_keys;
     
-    if (@sub_keys == 1) {
-      my $unique_value = shift @sub_keys;
-      $consensus{$key} = $unique_value;
-    } else {
+    if (@sub_keys > 1) {
       my @pairs = map { "$_=$met_counts{$key}->{$_}" } @sub_keys;
       push @errors, "There are " . scalar(@sub_keys) . " different values for metadata '$key' (".join(", ", @pairs).")";
       $consensus{$key} = join("|", @sub_keys);
+    } else {
+      my $unique_value = shift @sub_keys;
+      $consensus{$key} = $unique_value;
     }
   }
   

--- a/lib/perl/Bio/EnsEMBL/EGPipeline/BRC4Aligner/AggregateMetadata.pm
+++ b/lib/perl/Bio/EnsEMBL/EGPipeline/BRC4Aligner/AggregateMetadata.pm
@@ -1,0 +1,89 @@
+=head1 LICENSE
+
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=cut
+
+package Bio::EnsEMBL::EGPipeline::BRC4Aligner::AggregateMetadata;
+
+use strict;
+use warnings;
+use base ('Bio::EnsEMBL::EGPipeline::Common::RunnableDB::Base');
+
+use JSON;
+
+sub param_defaults {
+  my ($self) = @_;
+  
+  return {
+  };
+}
+
+sub fetch_input {
+  my ($self) = @_;
+}
+
+sub run {
+  my ($self) = @_;
+  
+  my $all_metadata = $self->param('aligner_metadata_array');
+  my $consensus_metadata = $self->create_consensus_metadata($all_metadata);
+
+  my $output_data = {
+    aggregated_aligner_metadata => $consensus_metadata,
+  };
+  $self->dataflow_output_id($output_data, 2);
+}
+
+sub create_consensus_metadata {
+  my ($self, $metadata_array) = @_;
+
+  my %met_counts = (
+    "is_paired" => {},
+    "is_stranded" => {},
+    "strand_direction" => {},
+    "strandness" => {}
+  );
+  
+  for my $met (@$metadata_array) {
+    for my $key (keys %$met) {
+      my $value = $met->{$key};
+      $met_counts{$key}{$value}++;
+    }
+  }
+  
+  # Check that there is only 1 value for each key
+  my %consensus;
+  my @errors;
+  for my $key (keys %met_counts) {
+    my @sub_keys = keys %{$met_counts{$key}};
+    
+    if (@sub_keys == 1) {
+      my $unique_value = shift @sub_keys;
+      $consensus{$key} = $unique_value;
+    } else {
+      push @errors, "There are " . scalar(@sub_keys) . " different values for metadata $key.";
+    }
+  }
+  
+  if (@errors) {
+    die("Could not create a consensus: " . join("; ", @errors));
+  }
+
+  return \%consensus;
+}
+
+1;

--- a/lib/perl/Bio/EnsEMBL/EGPipeline/BRC4Aligner/AlignSequence.pm
+++ b/lib/perl/Bio/EnsEMBL/EGPipeline/BRC4Aligner/AlignSequence.pm
@@ -52,8 +52,9 @@ sub fetch_input {
   my $samtools_dir  = $self->param('samtools_dir');
   my $max_intron    = $self->param('max_intron');
   my $gtf_file      = $self->param('gtf_file');
-  my $strandness    = $self->param('strandness');
   my $dnaseq        = $self->param('dnaseq');
+  my $aligner_metadata = $self->param_required('aligner_metadata');
+  my $strandness    = $aligner_metadata->{strandness};
 
   # DNA-Seq special changes
   $strandness = undef if $dnaseq;

--- a/lib/perl/Bio/EnsEMBL/EGPipeline/BRC4Aligner/BamStats.pm
+++ b/lib/perl/Bio/EnsEMBL/EGPipeline/BRC4Aligner/BamStats.pm
@@ -86,7 +86,8 @@ sub run_bam_stats {
     number_reads_mapped => $number_mapped,
     average_read_length => $average_read_length,
   );
-  $stats{number_pairs_mapped} = $stats->{'reads properly paired'} if $self->param_required('is_paired');
+  my $aligner_metadata = $self->param_required('aligner_metadata');
+  $stats{number_pairs_mapped} = $stats->{'reads properly paired'} if $aligner_metadata->{'is_paired'};
 
   return \%stats;
 }

--- a/lib/perl/Bio/EnsEMBL/EGPipeline/BRC4Aligner/CreateBedGraph.pm
+++ b/lib/perl/Bio/EnsEMBL/EGPipeline/BRC4Aligner/CreateBedGraph.pm
@@ -40,14 +40,15 @@ sub run {
   my $bamutils_dir  = $self->param('bamutils_dir');
   my $bam_file      = $self->param_required('bam_file');
   my $strand  = $self->param('strand');
-  my $direction  = $self->param('strand_direction');
+  my $aligner_metadata = $self->param_required('aligner_metadata');
+  my $strand_direction = $aligner_metadata->{'strand_direction'};
   
   my $bamutils = 'bamutils';
   if (defined $bamutils_dir) {
     $bamutils = "$bamutils_dir/$bamutils";
   }
 
-  my ($bed_file, $bed_cmd) = $self->convert_to_bed($bam_file, $strand, $direction);
+  my ($bed_file, $bed_cmd) = $self->convert_to_bed($bam_file, $strand, $strand_direction);
   
   $self->param('bed_file', $bed_file);
   $self->param('cmds',    $bed_cmd);

--- a/lib/perl/Bio/EnsEMBL/EGPipeline/BRC4Aligner/DatasetFactory.pm
+++ b/lib/perl/Bio/EnsEMBL/EGPipeline/BRC4Aligner/DatasetFactory.pm
@@ -1,0 +1,81 @@
+=head1 LICENSE
+
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=cut
+
+package Bio::EnsEMBL::EGPipeline::BRC4Aligner::DatasetFactory;
+
+use strict;
+use warnings;
+use base ('Bio::EnsEMBL::EGPipeline::Common::RunnableDB::Base');
+
+use Bio::EnsEMBL::ENA::SRA::BaseSraAdaptor qw(get_adaptor);
+
+use File::Path qw(make_path);
+use File::Spec::Functions qw(catdir);
+use JSON;
+
+sub param_defaults {
+  my ($self) = @_;
+  
+  return {
+  };
+}
+
+sub fetch_input {
+  my ($self) = @_;
+}
+
+sub run {
+  my ($self) = @_;
+  
+  my $datasets_file = $self->param('datasets_file');
+  my $organism = $self->param('organism');
+
+  print "Get datasets for $organism from $datasets_file\n";
+  my $datasets = $self->get_datasets($datasets_file, $organism);
+  print "Number of datasets: " . scalar(@$datasets) . "\n";
+
+  for my $dataset (@$datasets) {
+    $self->dataflow_output_id({ dataset_metadata => $dataset }, 2);
+  }
+}
+
+sub get_datasets {
+  my ($self, $datasets_file, $organism) = @_;
+  
+  my $json;
+  {
+    local $/; #enable slurp
+    open my $fh, "<", $datasets_file;
+    $json = <$fh>;
+  }
+
+  my $data = decode_json($json);
+
+  my @datasets;
+
+  for my $dataset (@$data) {
+    if ($dataset->{species} eq $organism) {
+      push @datasets, $dataset;
+    }
+  }
+
+  return \@datasets;
+}
+
+1;

--- a/lib/perl/Bio/EnsEMBL/EGPipeline/BRC4Aligner/DatasetFactory.pm
+++ b/lib/perl/Bio/EnsEMBL/EGPipeline/BRC4Aligner/DatasetFactory.pm
@@ -45,13 +45,20 @@ sub run {
   
   my $datasets_file = $self->param('datasets_file');
   my $organism = $self->param('organism');
+  my $results_dir = $self->param('results_dir');
 
   print "Get datasets for $organism from $datasets_file\n";
   my $datasets = $self->get_datasets($datasets_file, $organism);
   print "Number of datasets: " . scalar(@$datasets) . "\n";
 
   for my $dataset (@$datasets) {
-    $self->dataflow_output_id({ dataset_metadata => $dataset }, 2);
+    # Check there is not already a directory for this dataset
+    my $ds_dir = catdir($results_dir, $dataset->{name});
+    if (not -e $ds_dir) {
+      $self->dataflow_output_id({ dataset_metadata => $dataset }, 2);
+    } else {
+      $self->dataflow_output_id({ dataset_metadata => $dataset }, 3);
+    }
   }
 }
 

--- a/lib/perl/Bio/EnsEMBL/EGPipeline/BRC4Aligner/ExtractJunction.pm
+++ b/lib/perl/Bio/EnsEMBL/EGPipeline/BRC4Aligner/ExtractJunction.pm
@@ -31,9 +31,10 @@ sub run {
   my ($self) = @_;
   
   my $bam_file = $self->param_required('bam_file');
-  my $is_paired = $self->param('is_paired');
-  my $is_stranded = $self->param('is_stranded');
-  my $strand_direction = $self->param('strand_direction');
+  my $aligner_metadata = $self->param_required('aligner_metadata');
+  my $is_paired = $aligner_metadata->{'is_paired'};
+  my $is_stranded = $aligner_metadata->{'is_stranded'};
+  my $strand_direction = $aligner_metadata->{'strand_direction'};
 
   # Junction file
   my $bam_results_dir = $self->param_required('results_dir');

--- a/lib/perl/Bio/EnsEMBL/EGPipeline/BRC4Aligner/HtseqCountName.pm
+++ b/lib/perl/Bio/EnsEMBL/EGPipeline/BRC4Aligner/HtseqCountName.pm
@@ -46,8 +46,10 @@ sub run {
   my $gtf = $self->param_required('gtf_file');
   my $strand = $self->param_required('strand');
   my $number = $self->param_required('number');
-  my $strand_direction = $self->param('strand_direction');
   my $feature = $self->param('feature');
+
+  my $aligner_metadata = $self->param_required('aligner_metadata');
+  my $strand_direction = $aligner_metadata->{'strand_direction'};
 
   my $results_dir = dirname($bam);
 

--- a/lib/perl/Bio/EnsEMBL/EGPipeline/BRC4Aligner/HtseqCountName.pm
+++ b/lib/perl/Bio/EnsEMBL/EGPipeline/BRC4Aligner/HtseqCountName.pm
@@ -54,6 +54,7 @@ sub run {
   my $results_dir = dirname($bam);
 
   my $htseq_file = 'genes.htseq-union.' . $feature . '.' . $strand;
+  $htseq_file = 'genes.htseq-union.' . $strand if $feature eq 'exon';
   if ($number eq 'total') {
     $htseq_file .= '.nonunique';
   }

--- a/lib/perl/Bio/EnsEMBL/EGPipeline/BRC4Aligner/HtseqFactory.pm
+++ b/lib/perl/Bio/EnsEMBL/EGPipeline/BRC4Aligner/HtseqFactory.pm
@@ -38,7 +38,8 @@ sub write_output {
   my ($self) = @_;
 
   my $bam = $self->param_required('bam_file');
-  my $is_stranded = $self->param_required('is_stranded');
+  my $aligner_metadata = $self->param_required('aligner_metadata');
+  my $is_stranded = $aligner_metadata->{'is_stranded'};
   my $features = $self->param_required('features');
 
   my @strands = qw(firststrand secondstrand);

--- a/lib/perl/Bio/EnsEMBL/EGPipeline/BRC4Aligner/InferStrandness.pm
+++ b/lib/perl/Bio/EnsEMBL/EGPipeline/BRC4Aligner/InferStrandness.pm
@@ -42,8 +42,10 @@ sub run {
   my $bed_file = $self->param_required('bed_file');
   my $sam_file = $self->param_required('sam_file');
   my $n_samples = $self->param_required('n_samples');
-  my $input_is_paired = $self->param('input_is_paired');
-  my $input_is_stranded = $self->param('input_is_stranded');
+  
+  my $input_metadata = $self->param('input_metadata');
+  my $input_is_paired = $input_metadata->{'is_paired'};
+  my $input_is_stranded = $input_metadata->{'is_stranded'};
 
   my $sample_1 = $self->param('sample_seq_file_1');
   my $sample_2 = $self->param('sample_seq_file_2');
@@ -106,12 +108,15 @@ sub run {
   }
   close $LOG;
 
-  $self->dataflow_output_id({
+  my $aligner_metadata = {
       is_stranded => $is_stranded,
       is_paired => $is_paired,
       strand_direction => $strand_direction,
       strandness => $strandness,
-    },  1);
+  };
+  $self->dataflow_output_id({
+      aligner_metadata => $aligner_metadata
+    },  2);
 
   cleanup_file($sam_file);
   cleanup_file($self->param('sample_seq_file_1'));

--- a/lib/perl/Bio/EnsEMBL/EGPipeline/BRC4Aligner/MergeFastq.pm
+++ b/lib/perl/Bio/EnsEMBL/EGPipeline/BRC4Aligner/MergeFastq.pm
@@ -69,8 +69,8 @@ sub merge_fastq {
 
   # Only one run: no need to merge
   if (scalar(@$files1) == 1) {
-    rename $files1->[0], $output1;
-    rename $files2->[0], $output2 if @$files2;
+    rename $files1->[0], $output1 if not -s $output1;
+    rename $files2->[0], $output2 if @$files2 and not -s $output2;
   } else {
     
     # Merge the files in order

--- a/lib/perl/Bio/EnsEMBL/EGPipeline/BRC4Aligner/OrderBam.pm
+++ b/lib/perl/Bio/EnsEMBL/EGPipeline/BRC4Aligner/OrderBam.pm
@@ -36,7 +36,8 @@ sub write_output {
 
   my $input_bam = $self->param_required('input_bam');
   my $sorted_bam = $self->param_required('sorted_bam');
-  my $is_paired = $self->param_required('is_paired');
+  my $aligner_metadata = $self->param_required('aligner_metadata');
+  my $is_paired = $aligner_metadata->{'is_paired'};
 
   # Filter out unmapped reads or pairs
   my $filter = "";

--- a/lib/perl/Bio/EnsEMBL/EGPipeline/BRC4Aligner/PrepareFastq.pm
+++ b/lib/perl/Bio/EnsEMBL/EGPipeline/BRC4Aligner/PrepareFastq.pm
@@ -1,0 +1,51 @@
+=head1 LICENSE
+
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=cut
+
+package Bio::EnsEMBL::EGPipeline::BRC4Aligner::PrepareFastq;
+
+use strict;
+use warnings;
+use File::Spec::Functions;
+
+use base ('Bio::EnsEMBL::EGPipeline::Common::RunnableDB::Base');
+
+sub run {
+  my ($self) = @_;
+  
+  my $work_dir = $self->param_required('work_dir');
+  my $sample_name = $self->param_required("sample_name");
+
+  my $align_meta = $self->param_required('aggregated_aligner_metadata');
+  
+  my ($file1, $file2);
+  if ($align_meta->{is_paired}) {
+    $file1 = catfile($work_dir, $sample_name . "_all_1.fastq.gz");
+    $file2 = catfile($work_dir, $sample_name . "_all_2.fastq.gz");
+  } else {
+    $file1 = catfile($work_dir, $sample_name . "_all.fastq.gz");
+  }
+  
+  my $sample_data = {
+    sample_seq_file_1 => $file1,
+    sample_seq_file_2 => $file2,
+  };
+  $self->dataflow_output_id($sample_data, 2);
+}
+
+1;

--- a/lib/perl/Bio/EnsEMBL/EGPipeline/BRC4Aligner/SRASeqFile.pm
+++ b/lib/perl/Bio/EnsEMBL/EGPipeline/BRC4Aligner/SRASeqFile.pm
@@ -45,7 +45,7 @@ sub run {
   
   my $work_dir = $self->param_required('work_dir');
   my $run_id   = $self->param_required('run_id');
-  my $use_ncbi   = $self->param('use_ncbi');
+  my $fallback_ncbi   = $self->param('fallback_ncbi');
   
   make_path($work_dir) unless -e $work_dir;
   
@@ -76,7 +76,7 @@ sub run {
     } catch {
       my $error = $_;
 
-      if ($use_ncbi) {
+      if ($fallback_ncbi) {
         print STDERR "ERROR: $error\n";
         push @output_failed, { run_id => $run_id };
       } else {

--- a/lib/perl/Bio/EnsEMBL/EGPipeline/BRC4Aligner/SRASeqFileFromNCBI.pm
+++ b/lib/perl/Bio/EnsEMBL/EGPipeline/BRC4Aligner/SRASeqFileFromNCBI.pm
@@ -30,6 +30,7 @@ use File::Spec::Functions qw(catdir);
 use IO::Uncompress::Gunzip qw(gunzip $GunzipError);
 use LWP::Simple qw(getstore);
 use Carp;
+use Cwd qw(getcwd);
 
 sub run {
   my ($self) = @_;
@@ -70,7 +71,6 @@ sub retrieve_files {
   my ($self, $work_dir, $run) = @_;
   
   my $sra_dir = $self->param('sra_dir');
-  die "Can't download from NCBI without the -sra_dir parameter (dir where the fastq-dump binary is accessible)" if not $sra_dir;
   
   my $run_acc = $run->accession;
   my $sam_file = catdir($work_dir, "$run_acc.sam");
@@ -94,6 +94,8 @@ sub retrieve_files {
   
   my $sra_acc = $run_acc;
   my $download_sra = 0;
+  
+  my $previous_dir = getcwd();
   chdir $work_dir;
   if ($download_sra) {
     # Retrieve the SRA file
@@ -116,45 +118,62 @@ sub retrieve_files {
   
   # Next, extract the fastq file(s)
   warn "Getting file from fastq-dump";
+  
+  my $sra_dump_bin = $sra_dir ? "$sra_dir/fastq-dump": "fastq-dump";
+  
   # NB: -B ensures we get base-space data, not color-space
-  my $sra_command = "$sra_dir/fastq-dump -I -B --split-files --gzip $sra_acc";
+  my $sra_command = "$sra_dump_bin -I -B --split-files $sra_acc";
+  print("SRA download command: '$sra_command'\n");
   my $stats = `$sra_command`;
   
   # The downloaded files should be named {$run_acc}_1.gz or {$run_acc}.gz
   # Check file names and rename to our standard names
   
-  my $lone_fastq = "$run_acc.fastq.gz";
-  my $downloaded_1 = "${run_acc}_1.fastq.gz";
-  my $downloaded_2 = "${run_acc}_2.fastq.gz";
+  my $lone_fastq = "$run_acc.fastq";
+  my $downloaded_1 = "${run_acc}_1.fastq";
+  my $downloaded_2 = "${run_acc}_2.fastq";
+
   if (-f $lone_fastq) {
-    $seq_file_1 = "${run_acc}_all.fastq.gz";
+    $seq_file_1 = "${run_acc}_all.fastq";
     rename $lone_fastq, $seq_file_1;
+
+    `gzip $seq_file_1`;
+    $seq_file_1 .= '.gz';
   } elsif (-f $downloaded_1 and -f $downloaded_2) {
     # Check both files have the same number of lines
-    my $lines1 = `zcat $downloaded_1 | wc -l`; chomp $lines1;
-    my $lines2 = `zcat $downloaded_2 | wc -l`; chomp $lines2;
+    my $lines1 = `cat $downloaded_1 | wc -l`; chomp $lines1;
+    my $lines2 = `cat $downloaded_2 | wc -l`; chomp $lines2;
     if ($lines1 != $lines2) {
-      die("Extracted files have different line counts ($lines1 vs $lines2): $downloaded_1 and $downloaded_2");
+      die("Files have different line counts ($lines1 vs $lines2): $downloaded_1 and $downloaded_2");
     }
 
-    $seq_file_1 = "${run_acc}_all_1.fastq.gz";
-    $seq_file_2 = "${run_acc}_all_2.fastq.gz";
+    $seq_file_1 = "${run_acc}_all_1.fastq";
+    $seq_file_2 = "${run_acc}_all_2.fastq";
     rename $downloaded_1, $seq_file_1;
     rename $downloaded_2, $seq_file_2;
+    `gzip $seq_file_1`;
+    $seq_file_1 .= '.gz';
+    `gzip $seq_file_2`;
+    $seq_file_2 .= '.gz';
 
   } elsif (-f $downloaded_1) {
     warn("Using $downloaded_1 as the sole file for $run_acc");
-    $seq_file_1 = "${run_acc}_all.fastq.gz";
+    $seq_file_1 = "${run_acc}_all.fastq";
     rename $downloaded_1, $seq_file_1;
+    `gzip $seq_file_1`;
+    $seq_file_1 .= '.gz';
   } else {
+    chdir($previous_dir);
     die "Can't find the fastq files extracted for $run_acc downloaded in $work_dir";
   }
-  # Back to the root dir: need to update the seq files path
-  $seq_file_1 = catdir($work_dir, $seq_file_1);
-  $seq_file_2 = catdir($work_dir, $seq_file_2) if $seq_file_2;
   
   # Remove sra file
   unlink $sra_acc if -s $sra_acc;
+
+  # Back to the root dir: need to update the seq files path
+  chdir($previous_dir);
+  $seq_file_1 = catdir($work_dir, $seq_file_1);
+  $seq_file_2 = catdir($work_dir, $seq_file_2) if $seq_file_2;
   
   return ($seq_file_1, $seq_file_2, $sam_file);
 }

--- a/lib/perl/Bio/EnsEMBL/EGPipeline/BRC4Aligner/SampleFactory.pm
+++ b/lib/perl/Bio/EnsEMBL/EGPipeline/BRC4Aligner/SampleFactory.pm
@@ -1,0 +1,301 @@
+=head1 LICENSE
+
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=cut
+
+package Bio::EnsEMBL::EGPipeline::BRC4Aligner::SampleFactory;
+
+use strict;
+use warnings;
+use base ('Bio::EnsEMBL::EGPipeline::Common::RunnableDB::Base');
+
+use Bio::EnsEMBL::ENA::SRA::BaseSraAdaptor qw(get_adaptor);
+
+use File::Path qw(make_path);
+use File::Spec::Functions qw(catdir);
+use JSON;
+
+sub param_defaults {
+  my ($self) = @_;
+  
+  return {
+    'tax_id_restrict' => 0,
+    'check_library' => 1,
+    'default_direction' => 'reverse',
+  };
+}
+
+sub fetch_input {
+  my ($self) = @_;
+  
+  my $dba = $self->core_dba;
+  my $assembly = $dba->get_MetaContainer()->single_value_by_key('assembly.default');
+  $self->param('assembly', $assembly);
+}
+
+sub run {
+  my ($self) = @_;
+  
+  my $dataset = $self->param('dataset_metadata');
+  my $organism = $self->param('organism');
+  my $results_dir = $self->param('results_dir');
+  my $default_direction = $self->param('default_direction');
+
+  print "Number of runs for $dataset->{name}: " . scalar(@{ $dataset->{runs} }) . "\n";
+
+  my %unique_sample;
+  for my $sample (@{ $dataset->{runs} }) {
+    
+    # Sample data
+    my $sample_name = $sample->{name} // $sample->{accessions}->[0];
+    die "Missing sample name for $dataset->{name}" if not $sample_name;
+    if (exists $unique_sample{$sample_name}) {
+      die("There are several samples with the name $sample_name in the dataset $dataset->{name}");
+    } else {
+      $unique_sample{$sample_name} = 1;
+    }
+    
+    my $sample_dir = catdir($results_dir, $dataset->{name}, $sample_name);
+    make_path($sample_dir);
+
+    my $sample_bam_file = catdir($sample_dir, "results.bam");
+    (my $sorted_bam_file = $sample_bam_file) =~ s/\.bam/_name.bam/;
+    (my $sample_sam_file = $sample_bam_file) =~ s/\.bam/.sam/;
+
+    my $metadata_file = catdir($sample_dir, "metadata.json");
+
+    my @run_ids = $self->runs_from_sra_ids($sample->{accessions});
+    die "Could not retrieve run ids from accessions: " . join(", ", @{$sample->{accessions}}) if not @run_ids;
+
+    my %sample_data = (
+      component => $dataset->{component},
+      organism => $dataset->{species},
+      study_name => $dataset->{name},
+      accessions => \@run_ids,
+      trim_reads => $sample->{trim_reads} ? 1 : 0,
+      sample_name => $sample_name,
+      sample_dir => $sample_dir,
+      sample_bam_file => $sample_bam_file,
+      sample_sam_file => $sample_sam_file,
+      sorted_bam_file => $sorted_bam_file,
+      metadata_file => $metadata_file,
+    );
+    
+    # Input metadata provided separately
+    my %input_metadata = (
+      is_paired => $sample->{hasPairedEnds} ? 1 : 0,
+      is_stranded => $sample->{isStrandSpecific} ? 1 : 0,
+    );
+    
+    if ($input_metadata{is_stranded}) {
+      if ($sample->{strandDirection}) {
+        $input_metadata{strand_direction} = $sample->{strandDirection};
+      } else {
+        $input_metadata{strand_direction} = $default_direction;
+      }
+      
+      if ($input_metadata{is_paired}) {
+        if ($input_metadata{strand_direction} eq 'forward') {
+          $input_metadata{strandness} = "FR";
+        } elsif ($input_metadata{strand_direction} eq 'reverse') {
+          $input_metadata{strandness} = "RF";
+        }
+      } else {
+        if ($input_metadata{strand_direction} eq 'forward') {
+          $input_metadata{strandness} = "F";
+        } elsif ($input_metadata{strand_direction} eq 'reverse') {
+          $input_metadata{strandness} = "R";
+        }
+      }
+    }
+    $sample_data{input_metadata} = \%input_metadata;
+    
+    # In all cases, output the runs metadata (useful for htseq-count)
+    $self->dataflow_output_id(\%sample_data, 3);
+    
+    # Don't remake an existing file
+    if (not -s $sorted_bam_file) {
+      
+      # Also check that the sample file (might have a different name) doesn't already exist
+      my $sample_dl_dir = $self->param_required('species_work_dir');
+      my ($seq1, $seq2) = $self->has_sample_files($sample_dl_dir, $sample_name);
+      
+      if ($seq1) {
+        # No need to redownload the files
+        $sample_data{run_seq_files_1} = $seq1 ? [$seq1] : [];
+        $sample_data{run_seq_files_2} = $seq2 ? [$seq2] : [];
+        $self->dataflow_output_id(\%sample_data, 4);
+      } else {
+        for my $run_id (@run_ids) {
+          my %run_data = (
+            run_id => $run_id,
+          );
+          $self->dataflow_output_id(\%run_data, 2);
+        }
+      }
+      $self->dataflow_output_id(\%sample_data, 4);
+    }
+  }
+}
+
+sub has_sample_files {
+  my ($self, $sample_dir, $sample_name) = @_;
+  
+  my $base_name = "$sample_dir/$sample_name" . "_all";
+  my $unique_file = $base_name . ".fastq.gz";
+  my $paired_file_1 = $base_name . "_1.fastq.gz";
+  my $paired_file_2 = $base_name . "_2.fastq.gz";
+  
+  if (-s $unique_file) {
+    return ($unique_file, undef);
+  } elsif (-s $paired_file_1 and -s $paired_file_2) {
+    return ($paired_file_1, $paired_file_2);
+  } else {
+    return (undef, undef);
+  }
+}
+
+sub get_datasets {
+  my ($self, $datasets_file, $organism) = @_;
+  
+  my $json;
+  {
+    local $/; #enable slurp
+    open my $fh, "<", $datasets_file;
+    $json = <$fh>;
+  }
+
+  my $data = decode_json($json);
+
+  my @datasets;
+
+  for my $dataset (@$data) {
+    if ($dataset->{species} eq $organism) {
+      push @datasets, $dataset;
+    }
+  }
+
+  return \@datasets;
+}
+
+sub runs_from_sra_ids {
+  my ($self, $sra_ids) = @_;
+  
+  my $tax_id_restrict = $self->param_required('tax_id_restrict');
+  
+  my @runs;
+
+  print "Number of sra_ids: " . scalar(@$sra_ids) . "\n";
+  
+  my $run_adaptor = get_adaptor('Run');
+  my $study_adaptor = get_adaptor('Study');
+  my $exp_adaptor = get_adaptor('Experiment');
+  my $sample_adaptor = get_adaptor('Sample');
+  foreach my $sra_id (@$sra_ids) {
+
+    if ($sra_id =~ /^[ESD]RP/) {
+      # First look for a study
+      foreach my $study (@{$study_adaptor->get_by_accession($sra_id)}) {
+        die "No runs to retrieve from $sra_id" if not @{$study->runs()};
+        foreach my $run (@{$study->runs()}) {
+          push @runs, $run;
+        }
+      }
+    }
+
+    elsif ($sra_id =~ /^[ESD]RX/) {
+      # First look for an experiment
+      foreach my $exp (@{$exp_adaptor->get_by_accession($sra_id)}) {
+        die "No runs to retrieve from $sra_id" if not @{$exp->runs()};
+        foreach my $run (@{$exp->runs()}) {
+          push @runs, $run;
+        }
+      }
+    }
+
+    elsif ($sra_id =~ /^[ESD]RS/) {
+      # First look for a sample
+      foreach my $sample (@{$sample_adaptor->get_by_accession($sra_id)}) {
+        die "No runs to retrieve from $sra_id" if not @{$sample->runs()};
+        foreach my $run (@{$sample->runs()}) {
+          push @runs, $run;
+        }
+      }
+    }
+
+    # Next look for runs
+    elsif ($sra_id =~ /^[ESD]RR/) {
+      foreach my $run (@{$run_adaptor->get_by_accession($sra_id)}) {
+        push @runs, $run;
+      }
+    }
+    
+    else {
+      die "Unrecognized SRA accession pattern: $sra_id";
+    }
+
+  }
+  print "Number of runs: " . scalar(@runs) . "\n";
+  
+  # Filter to runs to only include the right species and transcriptomic data
+  my @filtered_runs;
+  foreach my $run (@runs) {
+    next if $tax_id_restrict and not $self->tax_id_match($run);
+    if ($self->param('check_library') and not $self->is_transcriptomic($run)) {
+      print $run->accession . " from @{$sra_ids} is not transcriptomic, skip\n";
+      next;
+    }
+    push @filtered_runs, $run->accession;
+  }
+  print "Number of filtered runs: " . scalar(@filtered_runs) . "\n";
+  
+  return @filtered_runs;
+}
+
+sub tax_id_match {
+  my ($self, $run) = @_;
+  
+  my $run_tax_id  = $run->sample()->taxon()->taxon_id();
+  my $mc          = $self->core_dba->get_MetaContainer();
+  my $taxonomy_id = $mc->single_value_by_key('species.taxonomy_id');
+  
+  return $run_tax_id eq $taxonomy_id;
+}
+
+sub is_transcriptomic {
+  my ($self, $run) = @_;
+  
+  my $is_transcriptomic = 0;
+  
+  # Check study type
+  my $study_type = $run->study()->type();
+  if ($study_type eq 'Transcriptome Analysis') {
+    $is_transcriptomic = 1;
+  }
+  
+  # Otherwise, check experiment type (in case the study is mixed)
+  my $design = $run->experiment()->design();
+  my $source = $design->{LIBRARY_DESCRIPTOR}->{LIBRARY_SOURCE};
+  if ($source eq 'TRANSCRIPTOMIC') {
+    $is_transcriptomic = 1;
+  }
+  
+  # Not RNAseq then
+  return $is_transcriptomic;
+}
+
+1;

--- a/lib/perl/Bio/EnsEMBL/EGPipeline/BRC4Aligner/SampleFactory.pm
+++ b/lib/perl/Bio/EnsEMBL/EGPipeline/BRC4Aligner/SampleFactory.pm
@@ -230,9 +230,13 @@ sub runs_from_sra_ids {
     elsif ($sra_id =~ /^[ESD]RS/) {
       # First look for a sample
       foreach my $sample (@{$sample_adaptor->get_by_accession($sra_id)}) {
-        die "No runs to retrieve from $sra_id" if not @{$sample->runs()};
-        foreach my $run (@{$sample->runs()}) {
-          push @runs, $run;
+        if (@{$sample->runs()}) {
+          foreach my $run (@{$sample->runs()}) {
+            push @runs, $run;
+          }
+        } else {
+          # Use the sample as if it was a run
+          push @runs, $sample;
         }
       }
     }

--- a/lib/perl/Bio/EnsEMBL/EGPipeline/BRC4Aligner/SplitReadStrand.pm
+++ b/lib/perl/Bio/EnsEMBL/EGPipeline/BRC4Aligner/SplitReadStrand.pm
@@ -31,9 +31,10 @@ sub run {
   $self->dbc and $self->dbc->disconnect_if_idle();
   
   my $bam_file = $self->param_required('bam_file');
-  my $is_paired = $self->param('is_paired');
-  my $is_stranded = $self->param('is_stranded');
-  my $strand_direction = $self->param('strand_direction');
+  my $aligner_metadata = $self->param_required('aligner_metadata');
+  my $is_paired = $aligner_metadata->{'is_paired'};
+  my $is_stranded = $aligner_metadata->{'is_stranded'};
+  my $strand_direction = $aligner_metadata->{'strand_direction'};
 
   # Split in two strand files
   if ($is_stranded) {

--- a/lib/perl/Bio/EnsEMBL/EGPipeline/BRC4Aligner/WriteMetadata.pm
+++ b/lib/perl/Bio/EnsEMBL/EGPipeline/BRC4Aligner/WriteMetadata.pm
@@ -35,18 +35,22 @@ sub write_output {
   my $results_dir = $self->param_required('results_dir');
   my $meta_file = catdir($results_dir, 'metadata.json');
 
+  my $aligner_metadata = $self->param_required('aligner_metadata');
+  my $is_paired = $aligner_metadata->{'is_paired'};
+  my $is_stranded = $aligner_metadata->{'is_stranded'};
+  my $strand_direction = $aligner_metadata->{'strand_direction'};
+
   my %metadata = (
     studyName => $self->param_required("study_name"),
     sraQueryString => $self->param_required("sample_name"),
   );
-  if (defined $self->param("is_paired")) {
-    $metadata{hasPairedEnds} = $self->param('is_paired') ? JSON::true : JSON::false;
+  if (defined $is_paired) {
+    $metadata{hasPairedEnds} = $is_paired ? JSON::true : JSON::false;
   }
-  if (defined $self->param("is_stranded")) {
-    $metadata{isStrandSpecific} = $self->param('is_stranded') ? JSON::true : JSON::false;
+  if (defined $is_stranded) {
+    $metadata{isStrandSpecific} = $is_stranded ? JSON::true : JSON::false;
 
     if ($self->param('is_stranded')) {
-      my $strand_direction = $self->param('strand_direction');
       $metadata{strandDirection} = $strand_direction;
     }
   }

--- a/lib/perl/Bio/EnsEMBL/EGPipeline/PipeConfig/SRAAlignment_BRC4_conf.pm
+++ b/lib/perl/Bio/EnsEMBL/EGPipeline/PipeConfig/SRAAlignment_BRC4_conf.pm
@@ -72,7 +72,7 @@ sub default_options {
     # If there is already an alignment for a sample, redo its htseq-count only
     # (do nothing otherwise)
     redo_htseqcount => 0,
-    features => ['exon', 'CDS'],
+    features => ['exon'],
     alignments_dir => undef,
     
     # Use input metadata, instead of inferring them (pair/strand)

--- a/lib/perl/Bio/EnsEMBL/EGPipeline/PipeConfig/SRAAlignment_BRC4_conf.pm
+++ b/lib/perl/Bio/EnsEMBL/EGPipeline/PipeConfig/SRAAlignment_BRC4_conf.pm
@@ -757,7 +757,7 @@ sub pipeline_analyses {
       -max_retry_count => 0,
       -flow_into         => {
         1 => [
-          '?accu_name=aligner_metadata_array&accu_input_variable=aligner_metadata&accu_address=[]',
+          '?accu_name=aligner_metadata_hash&accu_input_variable=aligner_metadata&accu_address={sample_name}',
         ],
       },
     },

--- a/lib/perl/Bio/EnsEMBL/EGPipeline/PipeConfig/SRAAlignment_BRC4_conf.pm
+++ b/lib/perl/Bio/EnsEMBL/EGPipeline/PipeConfig/SRAAlignment_BRC4_conf.pm
@@ -476,8 +476,17 @@ sub pipeline_analyses {
       -flow_into         => {
         '2->A' => WHEN("not #redo_htseqcount#", 'Sub_Samples_factory'),
         'A->2' => WHEN("not #redo_htseqcount#", 'Aggregate_metadata'),
-        '3' => WHEN("#redo_htseqcount#", 'Redo_Samples_factory'),
+        '2' => WHEN("#redo_htseqcount#", 'Redo_Samples_factory'),
+        '3' => 'Datasets_not_redone',
       },
+    },
+
+    {
+      -logic_name        => 'Datasets_not_redone',
+      -module     => 'Bio::EnsEMBL::Hive::RunnableDB::Dummy',
+      -rc_name           => 'normal',
+      -analysis_capacity => 1,
+      -max_retry_count => 0,
     },
 
     {


### PR DESCRIPTION
New version of the RNA-Seq pipeline
- use pipeline-wide params instead of INPUT_PLUS (simpler overall)
- semaphore the aligner metadata inferrence
- also group by dataset, so that we can check that the aligner metadata inferrence is the same for all runs (if not, complain)
- possible to override the metadata for a whole dataset in that case
- fix: if the accessions are sample ids, use them directly (can't retrieve runs or experiments from those anymore)