### PR TITLE
do not use .RepeatMaskerCache from the user $HOME; use "repeatmasker_cache" parameter instead

### DIFF
--- a/lib/perl/Bio/EnsEMBL/EGPipeline/DNAFeatures/REdatRepeatMasker.pm
+++ b/lib/perl/Bio/EnsEMBL/EGPipeline/DNAFeatures/REdatRepeatMasker.pm
@@ -35,10 +35,12 @@ sub fetch_runnable {
     %parameters = %{$self->param('parameters_hash')};
   }
   
-  #my $repeatmasker_cache = $self->param('repeatmasker_cache');
-  #if (defined $repeatmasker_cache && -e $repeatmasker_cache) {
-  #  $ENV{'REPEATMASKER_CACHE'} = $repeatmasker_cache;
-  #}
+  # fix to deal with "libexec/RepeatMasker" `$ENV{'HOME'} . "/.RepeatMaskerCache"` issue
+  #   many thanks to James Allen
+  my $repeatmasker_cache = $self->param('repeatmasker_cache');
+  if (defined $repeatmasker_cache && -e $repeatmasker_cache) {
+    $ENV{'HOME'} = $repeatmasker_cache;
+  }
   
   my $runnable = Bio::EnsEMBL::Analysis::Runnable::RepeatMasker->new
   (

--- a/lib/perl/Bio/EnsEMBL/EGPipeline/DNAFeatures/RepeatMasker.pm
+++ b/lib/perl/Bio/EnsEMBL/EGPipeline/DNAFeatures/RepeatMasker.pm
@@ -35,10 +35,12 @@ sub fetch_runnable {
     %parameters = %{$self->param('parameters_hash')};
   }
   
-  #my $repeatmasker_cache = $self->param('repeatmasker_cache');
-  #if (defined $repeatmasker_cache && -e $repeatmasker_cache) {
-  #  $ENV{'REPEATMASKER_CACHE'} = $repeatmasker_cache;
-  #}
+  # fix to deal with "libexec/RepeatMasker" `$ENV{'HOME'} . "/.RepeatMaskerCache"` issue
+  #   many thanks to James Allen
+  my $repeatmasker_cache = $self->param('repeatmasker_cache');
+  if (defined $repeatmasker_cache && -e $repeatmasker_cache) {
+    $ENV{'HOME'} = $repeatmasker_cache;
+  }
   
   my $runnable = Bio::EnsEMBL::Analysis::Runnable::RepeatMasker->new
   (


### PR DESCRIPTION
Dealing with outdated .RepeatMaskerCache issue in user home.
Passing "repeatmasker_cache" as a `HOME` env variable for RepeatModeler 

See repeatmasker `libexec/INSTALL` documentation: 
```
=== INSTALL
Library Cache Directories
-------------------------

Since version 3.0 RepeatMasker creates species-specific libraries
on the fly.  These libraries are cached in the first writable
directory in the programs library path.  The default path is:

  1. The RepeatMasker installation "Library" directory.
  2. The ".RepeatMaskerCache" subdirectory of the users home
     directory.
  3. The temporary processing directory "RM_#" created
     in the same directory as the sequence file and
     removed at the end of the run.

NOTE: If the program cannot save libraries in either path 1 or 2, the
libraries will need to be created each time the program runs.  This
will slow down runs on shorter sequences.
```

Many thanks to James Allen (@james-monkeyshines)