### PR TITLE
Mbarba/events

### DIFF
--- a/scripts/brc4/transfer_versions.pl
+++ b/scripts/brc4/transfer_versions.pl
@@ -51,7 +51,7 @@ for my $feat (@features) {
 }
 
 # Transfer descriptions
-if ($opt{update_descriptions}) {
+if ($opt{descriptions}) {
   $logger->info("Gene descriptions transfer:");
   update_descriptions($registry, $species, $old_data{gene}, $opt{write});
 }
@@ -87,7 +87,7 @@ if ($opt{events}) {
 }
 
 # Transfer versions
-if ($opt{update_versions}) {
+if ($opt{versions}) {
   $logger->info("Gene versions transfer:");
   # Update the version for the features we want to transfer and update
   for my $feat (@features) {
@@ -585,8 +585,8 @@ sub usage {
     NB: only run the history update once (otherwise you will have duplicates).
     
     Transfer:
-    --update_descriptions : Transfer the gene descriptions
-    --update_versions     : Transfer and increment the gene versions, and init the others
+    --descriptions : Transfer the gene descriptions
+    --versions     : Transfer and increment the gene versions, and init the others
     
     Use this to make actual changes:
     --write           : Do the actual changes (default is no changes to the database)
@@ -605,8 +605,8 @@ sub opt_check {
     "old_registry=s",
     "new_registry=s",
     "species=s",
-    "update_descriptions",
-    "update_versions",
+    "descriptions",
+    "versions",
     "events=s",
     "deletes=s",
     "write",

--- a/scripts/brc4/transfer_versions.pl
+++ b/scripts/brc4/transfer_versions.pl
@@ -13,6 +13,7 @@ my $logger = get_logger();
 use Bio::EnsEMBL::Registry;
 use Try::Tiny;
 use File::Path qw(make_path);
+use List::MoreUtils qw(uniq);
 
 ###############################################################################
 # MAIN
@@ -185,6 +186,16 @@ sub load_events {
     else {
       $logger->warn("Unsupported event '$event_name'? $line");
     }
+  }
+
+  # Ensure all event ids are unique in their groups
+  for my $merge_id (keys %merge_to) {
+    my @ids = uniq @{ $merge_to{$merge_id} };
+    $merge_to{$merge_id} = \@ids;
+  }
+  for my $split_id (keys %split_from) {
+    my @ids = uniq @{ $split_from{$split_id} };
+    $split_from{$split_id} = \@ids;
   }
 
   # Check for merge and splits involving the same ids (multi event)
@@ -406,7 +417,7 @@ sub update_descriptions {
 
       if (defined $old_description) {
         my $new_description = $old_description;
-        $logger->info("Transfer gene $id description: $new_description");
+        $logger->debug("Transfer gene $id description: $new_description");
         $update_count++;
 
         if ($update) {

--- a/scripts/brc4/transfer_versions.pl
+++ b/scripts/brc4/transfer_versions.pl
@@ -341,7 +341,7 @@ sub get_feat_data {
   my $fa = $registry->get_adaptor($species, "core", $feature);
   for my $feat (@{$fa->fetch_all}) {
     my $id = $feat->stable_id;
-    my $version = $feat->version;
+    my $version = $feat->version // 1;
     my $description;
     if ($feature eq 'gene') {
       $description = $feat->description;
@@ -457,18 +457,18 @@ sub add_events {
       }
       elsif ($event_name eq 'deleted') {
         my $id = $from[0];
-        my $version = $data->{$id}->{version};
+        my $version = $data->{$id}->{version} // 1;
         insert_event($dbc, $write, [$mapping_id, $feat, $id, $version, undef, undef]);
       }
       elsif ($event_name eq 'change') {
         my $id = $from[0];
-        my $old_version = $data->{$id}->{version};
+        my $old_version = $data->{$id}->{version} // 1;
         my $new_version = $old_version + 1;
         insert_event($dbc, $write, [$mapping_id, $feat, $id, $old_version, $id, $new_version]);
       }
       elsif ($event_name eq 'split' or $event_name eq 'merge' or $event_name eq 'multi') {
         for my $merge_id (@from) {
-          my $old_version = $data->{$merge_id}->{version};
+          my $old_version = $data->{$merge_id}->{version} // 1;
           for my $split_id (@to) {
             insert_event($dbc, $write, [$mapping_id, $feat, $merge_id, $old_version, $split_id, 1]);
           }

--- a/scripts/brc4/transfer_versions.pl
+++ b/scripts/brc4/transfer_versions.pl
@@ -495,14 +495,22 @@ sub usage {
     --new_registry <path> : Ensembl registry
     --species <str>   : production_name of one species
 
-    --update_descriptions    : Transfer the gene descriptions
+    You can do 2 things:
+    - Update the history
+    - Transfer the descriptions and version
+    (you can do both at the same time)
 
-    Use either of those:
-    --update_versions        : Transfer the gene versions, and init the others
-    or
+    History (use both events and deletes at the same time to make them part of the same session):
     --events <path>   : Path to an events file, to update the history and versions
     --deletes <path>  : Path to a list of deleted genes (to use with the events file)
+
+    NB: only run the history update once (otherwise you will have duplicates).
     
+    Transfer:
+    --update_descriptions : Transfer the gene descriptions
+    --update_versions     : Transfer and increment the gene versions, and init the others
+    
+    Use this to make actual changes:
     --write           : Do the actual changes (default is no changes to the database)
     
     --help            : show this help message


### PR DESCRIPTION
Add a new role to the script transfer_versions.pl: it can also update the stable id history in the core database. E.g. if it is provided with an event file and/or a deleted ids file, then it will create a mapping_session, and create stable_id_events for all changes in the ids (use --events and --deletes).