### PR TITLE
SRAAlignment_BRC4 pipeline - SUM count files and output TPM

### DIFF
--- a/lib/perl/Bio/EnsEMBL/EGPipeline/BRC4Aligner/CalculateTPM.pm
+++ b/lib/perl/Bio/EnsEMBL/EGPipeline/BRC4Aligner/CalculateTPM.pm
@@ -22,15 +22,6 @@ use strict;
 use warnings;
 use base ('Bio::EnsEMBL::EGPipeline::BRC4Aligner::Base');
 
-sub param_defaults {
-  my ($self) = @_;
-
-  return {
-    # Features on which to count the read
-    features => 'exon',
-  };
-
-}
 
 sub run {
   my ($self) = @_;

--- a/lib/perl/Bio/EnsEMBL/EGPipeline/BRC4Aligner/CalculateTPM.pm
+++ b/lib/perl/Bio/EnsEMBL/EGPipeline/BRC4Aligner/CalculateTPM.pm
@@ -18,7 +18,6 @@ limitations under the License.
 =cut
 
 package Bio::EnsEMBL::EGPipeline::BRC4Aligner::CalculateTPM;
-use Data::Dumper qw(Dumper);
 use strict;
 use warnings;
 use base ('Bio::EnsEMBL::EGPipeline::BRC4Aligner::Base');

--- a/lib/perl/Bio/EnsEMBL/EGPipeline/BRC4Aligner/CalculateTPM.pm
+++ b/lib/perl/Bio/EnsEMBL/EGPipeline/BRC4Aligner/CalculateTPM.pm
@@ -1,0 +1,82 @@
+=head1 LICENSE
+
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=cut
+
+package Bio::EnsEMBL::EGPipeline::BRC4Aligner::CalculateTPM;
+use Data::Dumper qw(Dumper);
+use strict;
+use warnings;
+use base ('Bio::EnsEMBL::EGPipeline::BRC4Aligner::Base');
+
+sub param_defaults {
+  my ($self) = @_;
+
+  return {
+    # Features on which to count the read
+    features => 'exon',
+  };
+
+}
+
+sub run {
+  my ($self) = @_;
+
+  my $sum_htseq_file = $self->param_required('sum_file');
+  my $fl_file = $self->param_required('fl_file');
+  my $tpm_htseq_file = $sum_htseq_file . ".tpm";
+  my $rpk_htseq_file = $sum_htseq_file . ".rpk";
+
+  my @rpk_args = ( "bash", "-c", "join <(sort -k1 $sum_htseq_file) <(sort -k1 $fl_file) | awk '{print \$1\"\t\"\$2/(\$3/1000)}' > $rpk_htseq_file" );
+  system(@rpk_args);
+
+  open my $fh, '<', $rpk_htseq_file or die $!;
+
+  my $total = 0;
+
+  while (<$fh>) {
+    my @data = split /\t/, $_;
+
+    die "The $rpk_htseq_file contains more than 3 columns. Exiting." unless scalar(@data) == 2;
+
+    my $gene_id     	  = $data[0];
+    my $gene_factor   	  = $data[1];
+
+    $total += $gene_factor;
+  }
+
+  my $million_factor = $total/1000000;
+
+  my @tpm_args = ( "bash", "-c", "awk -v million_factor=\"$million_factor\" '{print \$1\"\t\"\$2/million_factor}' $rpk_htseq_file > $tpm_htseq_file");
+  system(@tpm_args);
+
+  unlink $rpk_htseq_file;
+
+  $self->param("tpm_htseq_file", $tpm_htseq_file);
+}
+
+sub write_output {
+
+  my ($self) = @_;
+
+  my $tpm_htseq_file = $self->param("tpm_htseq_file");
+
+  $self->dataflow_output_id({ tpm_htseq_file => $tpm_htseq_file }, 2);
+
+}
+
+1;

--- a/lib/perl/Bio/EnsEMBL/EGPipeline/BRC4Aligner/GTF_to_featurelength.pm
+++ b/lib/perl/Bio/EnsEMBL/EGPipeline/BRC4Aligner/GTF_to_featurelength.pm
@@ -1,0 +1,92 @@
+=head1 LICENSE
+
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=cut
+
+package Bio::EnsEMBL::EGPipeline::BRC4Aligner::GTF_to_featurelength;
+
+use strict;
+use warnings;
+use base ('Bio::EnsEMBL::EGPipeline::Common::RunnableDB::Base');
+
+sub run {
+  my ($self) = @_;
+
+  my $gtf_file = $self->param_required('gtf_file');
+  my $fl_file = $self->param_required('fl_file');
+
+  my %el_dict;
+
+  open my $gtf, "<", $gtf_file or die("$gtf_file: $!");
+  open my $el, ">", $fl_file or die("$fl_file: $!");
+
+  while (my $line = readline($gtf)) {
+      next if $line =~ /^#/;
+      chomp $line;
+
+      my ($chr, $source, $type, $start, $end, $score, $strand, $phase, $attr_list) = split /\t/, $line;
+
+      # We only need exons positions here
+      next if $type ne 'exon';
+
+      # Get exon's length
+      my $exon_length = abs($start - $end);
+
+      # The exon id is needed
+      my %attr = get_attributes($attr_list);
+      my $gene_id = $attr{"gene_id"};
+      $gene_id =~ s/"//g;
+
+      # Increase the genes length value by the exon's length in the dict:
+      $el_dict{$gene_id} += $exon_length;
+  }
+
+  my $gene_id;
+  my $exons_total_length;
+while ( ($gene_id,$exons_total_length) = each %el_dict ) {
+
+    my @out_line = ($gene_id, $exons_total_length);
+
+    print $el join("\t", @out_line) . "\n";
+  }
+  close $gtf;
+  close $el;
+
+  $self->param('fl_file', $fl_file);
+}
+
+sub write_output {
+  my ($self) = @_;
+
+  $self->dataflow_output_id({ fl_file => $self->param('fl_file') },  2);
+}
+
+sub get_attributes {
+  my ($attr_list) = @_;
+
+  my @attrs = split /; /, $attr_list;
+
+  my %attrs_dict;
+  for my $attr (@attrs) {
+    if ($attr =~ /^(.+) (.+)$/) {
+      $attrs_dict{$1} = $2;
+    }
+  }
+  return %attrs_dict;
+}
+
+1;

--- a/lib/perl/Bio/EnsEMBL/EGPipeline/BRC4Aligner/HtseqCountName.pm
+++ b/lib/perl/Bio/EnsEMBL/EGPipeline/BRC4Aligner/HtseqCountName.pm
@@ -101,12 +101,26 @@ sub run {
   my $cmd = $self->run_htseq_count($bam, $gtf, $htseq_file, $params);
   
   $self->param("cmd", $cmd);
+  $self->param("htseq_file", $htseq_file);
+  $self->param("strand", $strand);
+  $self->param("feature", $feature);
+  $self->param("number", $number);
 }
 
 sub write_output {
   my ($self) = @_;
   
   my $cmd = $self->param("cmd");
+  my $htseq_file = $self->param("htseq_file");
+  my $strand = $self->param("strand");
+  my $feature = $self->param("feature");
+  my $number = $self->param("number");
+
+  my %case =  ( "htseq_file" => $htseq_file,
+      "strand"               => $strand,
+      "feature"              => $feature,
+      "number"               => $number,
+  );
   
   my $version = $self->get_htseq_version();
 
@@ -118,6 +132,7 @@ sub write_output {
   $self->store_align_cmds($align_cmds);
   
   $self->dataflow_output_id({ cmds => $cmd },  2);
+  $self->dataflow_output_id({ case => \%case },  3);
 }
 
 sub get_htseq_version {

--- a/lib/perl/Bio/EnsEMBL/EGPipeline/BRC4Aligner/PrepareGenome.pm
+++ b/lib/perl/Bio/EnsEMBL/EGPipeline/BRC4Aligner/PrepareGenome.pm
@@ -37,17 +37,18 @@ sub write_output {
   my $pipeline_dir = $self->param_required('pipeline_dir');
 
   my %genome_metadata = (
-    species => $species,
+      species             => $species,
 
-    species_results_dir => catdir($results_dir, $component, $organism),
+      species_results_dir => catdir($results_dir, $component, $organism),
 
-    species_work_dir => catdir($pipeline_dir, $species),
-    genome_dir => $genome_dir,
-    genome_file => catdir($genome_dir, $species . ".fa"),
-    length_file => catdir($genome_dir, $species . ".fa.lengths.txt"),
-    genome_bed_file => catdir($genome_dir, $species . ".bed"),
-    genome_gff_file => catdir($genome_dir, $species . ".gff"),
-    genome_gtf_file => catdir($genome_dir, $species . ".gtf"),
+      species_work_dir    => catdir($pipeline_dir, $species),
+      genome_dir          => $genome_dir,
+      genome_file         => catdir($genome_dir, $species . ".fa"),
+      length_file         => catdir($genome_dir, $species . ".fa.lengths.txt"),
+      genome_bed_file     => catdir($genome_dir, $species . ".bed"),
+      genome_gff_file     => catdir($genome_dir, $species . ".gff"),
+      genome_gtf_file     => catdir($genome_dir, $species . ".gtf"),
+      genome_fl_file      => catdir($genome_dir, $species . ".feature_length_per_gene.tsv"),
   );
 
   $self->dataflow_output_id(\%genome_metadata, 1);

--- a/lib/perl/Bio/EnsEMBL/EGPipeline/BRC4Aligner/SumHtseqFiles.pm
+++ b/lib/perl/Bio/EnsEMBL/EGPipeline/BRC4Aligner/SumHtseqFiles.pm
@@ -1,0 +1,109 @@
+=head1 LICENSE
+
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=cut
+
+package Bio::EnsEMBL::EGPipeline::BRC4Aligner::SumHtseqFiles;
+use strict;
+use warnings;
+
+use base ('Bio::EnsEMBL::EGPipeline::BRC4Aligner::Base');
+
+use Data::Dumper qw(Dumper);
+use File::Basename qw(dirname);
+use File::Spec::Functions qw(catdir catfile);
+
+
+sub param_defaults {
+  my ($self) = @_;
+
+  return {
+    # Features on which to count the read
+    features => 'exon',
+  };
+}
+
+sub run {
+  my ($self) = @_;
+
+  my $cases = $self->param('case');
+  my @unstranded;
+  my @uniquestranded;
+  my @nonuniquestranded;
+  my @sum_htseq_files;
+
+  for my $case_hash (@$cases) {
+    push @unstranded, $case_hash if $case_hash->{"strand"} eq 'unstranded';
+    push @uniquestranded, $case_hash if ($case_hash->{"strand"} ne 'stranded') && ($case_hash->{"number"} eq 'unique');
+    push @nonuniquestranded, $case_hash if ($case_hash->{"strand"} ne 'stranded') && ($case_hash->{"number"} eq 'total');
+  }
+
+  #Unstranded
+  if (@unstranded != 0) {
+    my @unstranded_htseq_files = map {$_->{htseq_file}} @unstranded;
+    for my $unstranded_htseq_file (@unstranded_htseq_files) {
+      push @sum_htseq_files, $unstranded_htseq_file
+    };
+  };
+
+  if (@uniquestranded != 0) {
+    my @uqstranded_htseq_files = map {$_->{htseq_file}} @uniquestranded;
+    my $results_dir = dirname($uqstranded_htseq_files[0]);
+    my $sum_uqstranded_htseq_file = catfile($results_dir, 'genes.htseq-union.stranded.sum.counts');
+    my $uqstranded_htseq_files_str = join " ", @uqstranded_htseq_files;
+    my $sum_uqstranded_htseq_file_output = `cat $uqstranded_htseq_files_str | awk '{a[\$1]+=\$2}END{for(i in a) print i,a[i]}' > $sum_uqstranded_htseq_file`;
+    push @sum_htseq_files, $sum_uqstranded_htseq_file;
+  };
+
+
+  if (@nonuniquestranded != 0) {
+    my @nuqstranded_htseq_files = map {$_->{htseq_file}} @nonuniquestranded;
+    my $results_dir = dirname($nuqstranded_htseq_files[0]);
+    my $sum_nuqstranded_htseq_file = catfile($results_dir, 'genes.htseq-union.stranded.nonunique.sum.counts');
+    my $nuqstranded_htseq_files_str = join " ", @nuqstranded_htseq_files;
+    my $sum_nuqstranded_htseq_file_output = `cat $nuqstranded_htseq_files_str | awk '{a[\$1]+=\$2}END{for(i in a) print i,a[i]}' > $sum_nuqstranded_htseq_file`;
+    push @sum_htseq_files, $sum_nuqstranded_htseq_file;
+  };
+
+  for my $sum_htseq_file (@sum_htseq_files) {
+    print($sum_htseq_file."\n");
+  }
+
+  $self->param("sum_htseq_files", \@sum_htseq_files);
+}
+
+sub write_output {
+
+  my ($self) = @_;
+
+  my @sum_htseq_files = @{ $self->param("sum_htseq_files") };
+
+  my @cases;
+
+  for my $sum_htseq_file (@sum_htseq_files) {
+    push @cases, {
+        sum_file => $sum_htseq_file,
+    };
+  }
+
+  for my $case (@cases) {
+    $self->dataflow_output_id($case, 2);
+  }
+
+}
+
+1;

--- a/lib/perl/Bio/EnsEMBL/EGPipeline/BRC4Aligner/SumHtseqFiles.pm
+++ b/lib/perl/Bio/EnsEMBL/EGPipeline/BRC4Aligner/SumHtseqFiles.pm
@@ -27,14 +27,6 @@ use File::Basename qw(dirname);
 use File::Spec::Functions qw(catdir catfile);
 
 
-sub param_defaults {
-  my ($self) = @_;
-
-  return {
-    # Features on which to count the read
-    features => 'exon',
-  };
-}
 
 sub run {
   my ($self) = @_;

--- a/lib/perl/Bio/EnsEMBL/EGPipeline/BRC4Aligner/SumHtseqFiles.pm
+++ b/lib/perl/Bio/EnsEMBL/EGPipeline/BRC4Aligner/SumHtseqFiles.pm
@@ -23,7 +23,6 @@ use warnings;
 
 use base ('Bio::EnsEMBL::EGPipeline::BRC4Aligner::Base');
 
-use Data::Dumper qw(Dumper);
 use File::Basename qw(dirname);
 use File::Spec::Functions qw(catdir catfile);
 

--- a/lib/perl/Bio/EnsEMBL/EGPipeline/BRC4Aligner/SyncAlignmentFiles.pm
+++ b/lib/perl/Bio/EnsEMBL/EGPipeline/BRC4Aligner/SyncAlignmentFiles.pm
@@ -33,8 +33,10 @@ use JSON;
 sub fetch_input {
   my ($self) = @_;
   
-  my $component = $self->param_required("component");
-  my $organism = $self->param_required("organism");
+  my $component = $self->param("component");
+  my $organism = $self->param("organism");
+  $component = 'component' if not $component;
+  $organism = $self->param("species") if not $organism;
   my $dataset = $self->param_required("study_name");
   my $sample = $self->param_required("sample_name");
   

--- a/lib/perl/Bio/EnsEMBL/EGPipeline/PipeConfig/SRAAlignment_BRC4_conf.pm
+++ b/lib/perl/Bio/EnsEMBL/EGPipeline/PipeConfig/SRAAlignment_BRC4_conf.pm
@@ -956,7 +956,19 @@ sub pipeline_analyses {
       },
       -rc_name           => 'normal',
       -max_retry_count => 0,
+      -flow_into => 'gtf_to_featurelength',
     },
+    {
+      -logic_name        => 'gtf_to_featurelength',
+      -module            => 'Bio::EnsEMBL::EGPipeline::BRC4Aligner::GTF_to_featurelength',
+      -rc_name           => 'normal',
+      -max_retry_count => 0,
+      -parameters        => {
+        gtf_file          => '#genome_gtf_file#',
+        fl_file          => '#genome_fl_file#',
+      },
+    },
+
 
     {
       -logic_name        => 'Dump_genome',
@@ -1200,7 +1212,8 @@ sub pipeline_analyses {
       -analysis_capacity => 1,
       -max_retry_count => 0,
       -flow_into         => {
-        2 => 'HtseqCount_redo',
+        '2->A' => ['HtseqCount_redo'],
+        'A->1' => ['SumHtseqFiles_redo'],
       },
     },
 
@@ -1212,6 +1225,31 @@ sub pipeline_analyses {
         results_dir    => '#sample_dir#',
       },
       -rc_name           => 'normal',
+      -analysis_capacity => 25,
+      -max_retry_count => 0,
+      -flow_into      => {
+          3 => '?accu_name=case&accu_address=[]',
+      },
+    },
+
+        {
+      -logic_name        => 'SumHtseqFiles_redo',
+      -module            => 'Bio::EnsEMBL::EGPipeline::BRC4Aligner::SumHtseqFiles',
+      -rc_name           => 'normal',
+      -analysis_capacity => 25,
+      -max_retry_count => 0,
+      -flow_into      => {
+          2 => 'CalculateTPM_redo',
+      },
+    },
+
+    {
+      -logic_name        => 'CalculateTPM_redo',
+      -module            => 'Bio::EnsEMBL::EGPipeline::BRC4Aligner::CalculateTPM',
+      -rc_name           => 'normal',
+      -parameters        => {
+        fl_file          => '#genome_fl_file#',
+      },
       -analysis_capacity => 25,
       -max_retry_count => 0,
     },
@@ -1617,7 +1655,8 @@ sub pipeline_analyses {
       -analysis_capacity => 1,
       -max_retry_count => 0,
       -flow_into         => {
-        2 => 'HtseqCount',
+        '2->A' => ['HtseqCount'],
+        'A->1' => ['SumHtseqFiles'],
       },
     },
 
@@ -1630,6 +1669,31 @@ sub pipeline_analyses {
         results_dir    => '#sample_dir#',
       },
       -rc_name           => 'normal',
+      -analysis_capacity => 25,
+      -max_retry_count => 0,
+      -flow_into      => {
+          3 => '?accu_name=case&accu_address=[]',
+      },
+    },
+
+    {
+      -logic_name        => 'SumHtseqFiles',
+      -module            => 'Bio::EnsEMBL::EGPipeline::BRC4Aligner::SumHtseqFiles',
+      -rc_name           => 'normal',
+      -analysis_capacity => 25,
+      -max_retry_count => 0,
+      -flow_into      => {
+          2 => 'CalculateTPM',
+      },
+    },
+
+    {
+      -logic_name        => 'CalculateTPM',
+      -module            => 'Bio::EnsEMBL::EGPipeline::BRC4Aligner::CalculateTPM',
+      -rc_name           => 'normal',
+      -parameters        => {
+        fl_file          => '#genome_fl_file#',
+      },
       -analysis_capacity => 25,
       -max_retry_count => 0,
     },


### PR DESCRIPTION
New pipeline developments for summing htseq count files and outputting TPM counts as well.

### New analyses were added
- GTF_to_featurelength.pm: This analysis takes the dumped GTF file and calculates the total length of the exons per gene and stores this information in a new (featurelength) file (fl_file, catdir($genome_dir, $species . ".feature_length_per_gene.tsv")).
- SumHtseqFiles.pm: This analysis takes all the htseq_files created by the HtseqCount analysis and sum the strand-specific counts together. For unstranded htseq files it does nothing. It outputs all the summed stranded and/or unstranded count files.
- CalculateTPM: This new analysis calculates TPM values per gene for each of the summed count files.

### Modified analyses
- PrepareGenome.pm: Defines the genome_fl_file needed by the GTF_to_featurelength.pm analysis.
- HtseqCountName.pm: It now flows a hash of htseq_files paths and their attributes to an accumulator (case) which is then used by the SumHtseqFiles.
- SyncAlignmentFiles.pm: Minor fixes to variables definition (when component and/or organism variables are undef).

### Modified Pipeconfig
SRAAlignment_BRC4_conf.pm has been modified to include the new analyses. Both the redo and the normal htseq workflows have been updated and work fine. 


### Testing
The new analyses have been tested with stranded/unstranded data as part of the normal and the redo htseq workflows. The output summed counts and the TPM values have been compared to corresponding values that have been computed by a different pipeline for the same studies and they are similar.