### PR TITLE
Fix default cmscan parameters

### DIFF
--- a/lib/perl/Bio/EnsEMBL/EGPipeline/PipeConfig/RNAFeatures_conf.pm
+++ b/lib/perl/Bio/EnsEMBL/EGPipeline/PipeConfig/RNAFeatures_conf.pm
@@ -88,10 +88,10 @@ sub default_options {
     clanin_file       => undef,
     cmscan_param_hash =>
     {
-      cpu            => $self->o('cmscan_cpu'),
-      heuristics     => $self->o('cmscan_heuristics'),
-      threshold      => $self->o('cmscan_threshold'),
-      clanin_file    => $self->o('clanin_file'),
+      -cpu            => $self->o('cmscan_cpu'),
+      -heuristics     => $self->o('cmscan_heuristics'),
+      -threshold      => $self->o('cmscan_threshold'),
+      -clanin_file    => $self->o('clanin_file'),
     },
     cmscan_parameters => '',
     cmsscan_resource_class => 'cmscan_4Gb_mem',


### PR DESCRIPTION
Fix a sneaky bug, where the parameters need a hyphen to be passed correctly to the CMscan analysis constructor rearrange function Because the params include additional keys with hyphen (-analysis, -cm_file), there is a 2/6 chance that is will be read and used silently, and 3/6 chance that the runnable will fail. Rerunning the runnable makes it more likely to pass this, by chance alone. But that also means that the other params were not used.

Just readding the hyphens fixes the issue.