### PR TITLE
Fix bug causing extra unwanted count/tpm files

### DIFF
--- a/lib/perl/Bio/EnsEMBL/EGPipeline/BRC4Aligner/SumHtseqFiles.pm
+++ b/lib/perl/Bio/EnsEMBL/EGPipeline/BRC4Aligner/SumHtseqFiles.pm
@@ -39,8 +39,8 @@ sub run {
 
   for my $case_hash (@$cases) {
     push @unstranded, $case_hash if $case_hash->{"strand"} eq 'unstranded';
-    push @uniquestranded, $case_hash if ($case_hash->{"strand"} ne 'stranded') && ($case_hash->{"number"} eq 'unique');
-    push @nonuniquestranded, $case_hash if ($case_hash->{"strand"} ne 'stranded') && ($case_hash->{"number"} eq 'total');
+    push @uniquestranded, $case_hash if ($case_hash->{"strand"} ne 'unstranded') && ($case_hash->{"number"} eq 'unique');
+    push @nonuniquestranded, $case_hash if ($case_hash->{"strand"} ne 'unstranded') && ($case_hash->{"number"} eq 'total');
   }
 
   #Unstranded

--- a/lib/perl/Bio/EnsEMBL/EGPipeline/BRC4Aligner/SumHtseqFiles.pm
+++ b/lib/perl/Bio/EnsEMBL/EGPipeline/BRC4Aligner/SumHtseqFiles.pm
@@ -38,10 +38,15 @@ sub run {
   my @sum_htseq_files;
 
   for my $case_hash (@$cases) {
-    push @unstranded, $case_hash if $case_hash->{"strand"} eq 'unstranded';
-    push @uniquestranded, $case_hash if ($case_hash->{"strand"} ne 'unstranded') && ($case_hash->{"number"} eq 'unique');
-    push @nonuniquestranded, $case_hash if ($case_hash->{"strand"} ne 'unstranded') && ($case_hash->{"number"} eq 'total');
+  
+    if ($case_hash->{"strand"} eq 'unstranded') {
+      push @unstranded, $case_hash;
+    } else {
+      push @uniquestranded, $case_hash if $case_hash->{"number"} eq 'unique';
+      push @nonuniquestranded, $case_hash if $case_hash->{"number"} eq 'total';
+    }
   }
+  
 
   #Unstranded
   if (@unstranded != 0) {


### PR DESCRIPTION
This typo was causing the pipeline to generate .stranded.(nonunique).sum.counts files (and subsequently .stranded.(nonunique).sum.counts.tpm files) for "unstranded" runs. 
Note that this bug was not affecting the correct "stranded" and "unstranded" count/sum files which were produced for "stranded" and "unstranded" runs.

The fix was applied and tested by comparing the TPM values of several runs against those of another pipeline for the same samples (agaist different assemblies though). See [here](https://drive.google.com/file/d/1ltvzA1e26-R5pkopKmlaClzrzp5iCt4I/view?usp=sharing).