### PR TITLE
Mbarba/no strandness

### DIFF
--- a/lib/perl/Bio/EnsEMBL/EGPipeline/BRC4Aligner/AggregateMetadata.pm
+++ b/lib/perl/Bio/EnsEMBL/EGPipeline/BRC4Aligner/AggregateMetadata.pm
@@ -66,7 +66,7 @@ sub check_metadata {
   
   my @errors;
   if (not $self->param('ignore_single_paired') and not defined $met->{is_paired}) {
-    push @errors, "No 'is_paired' value"
+    push @errors, "No 'is_paired' value";
   }
   push @errors, "No 'is_stranded' value" if not defined $met->{is_stranded};
   if ($met->{is_stranded}) {

--- a/lib/perl/Bio/EnsEMBL/EGPipeline/BRC4Aligner/AggregateMetadata.pm
+++ b/lib/perl/Bio/EnsEMBL/EGPipeline/BRC4Aligner/AggregateMetadata.pm
@@ -90,7 +90,7 @@ sub create_consensus_metadata {
     my $met = $metadata_hash->{$sample};
     for my $key (keys %$met) {
       my $value = $met->{$key};
-      if ($key eq 'stranded_ambiguous') {
+      if ($key eq 'stranded_ambiguous' and $value == 1) {
         push @stranded_ambiguous, $met;
       } else {
         $met_counts{$key}{$value}++;

--- a/lib/perl/Bio/EnsEMBL/EGPipeline/BRC4Aligner/AggregateMetadata.pm
+++ b/lib/perl/Bio/EnsEMBL/EGPipeline/BRC4Aligner/AggregateMetadata.pm
@@ -69,7 +69,6 @@ sub check_metadata {
   }
   push @errors, "No 'is_stranded' value" if not defined $met->{is_stranded};
   if ($met->{is_stranded}) {
-    push @errors, "No 'strandness' value" if not defined $met->{strandness};
     push @errors, "No 'strand_direction' value" if not defined $met->{strand_direction};
   }
   
@@ -83,7 +82,6 @@ sub create_consensus_metadata {
     "is_paired" => {},
     "is_stranded" => {},
     "strand_direction" => {},
-    "strandness" => {}
   );
   
   for my $sample (keys %$metadata_hash) {

--- a/lib/perl/Bio/EnsEMBL/EGPipeline/BRC4Aligner/AlignSequence.pm
+++ b/lib/perl/Bio/EnsEMBL/EGPipeline/BRC4Aligner/AlignSequence.pm
@@ -54,11 +54,12 @@ sub fetch_input {
   my $gtf_file      = $self->param('gtf_file');
   my $dnaseq        = $self->param('dnaseq');
   my $aligner_metadata = $self->param_required('aligner_metadata');
-  my $strandness    = $aligner_metadata->{strandness};
+  my $strand_direction = $aligner_metadata->{strand_direction};
+  my $is_paired     = $self->param('is_paired');
   my $no_spliced    = $self->param('no_spliced');
 
   # DNA-Seq special changes
-  $strandness = undef if $dnaseq;
+  $strand_direction = undef if $dnaseq;
   if ($dnaseq) {
     $no_spliced = 1;
   }
@@ -78,7 +79,8 @@ sub fetch_input {
     -run_mode          => $run_mode,
     -gtf_file          => $gtf_file,
     -max_intron_length => $max_intron_length,
-    -strandness        => $strandness,
+    -strand_direction  => $strand_direction,
+    -is_paired         => $is_paired,
     -no_spliced        => $no_spliced,
     -number_primary    => $number_primary,
   );

--- a/lib/perl/Bio/EnsEMBL/EGPipeline/BRC4Aligner/DatasetFactory.pm
+++ b/lib/perl/Bio/EnsEMBL/EGPipeline/BRC4Aligner/DatasetFactory.pm
@@ -138,7 +138,7 @@ sub get_datasets {
   my @datasets;
 
   for my $dataset (@$data) {
-    $dataset = transform_bools($dataset);
+    transform_bools($dataset);
     if ($dataset->{species} and $dataset->{species} eq $organism) {
       push @datasets, $dataset;
     } elsif ($dataset->{production_name} and $dataset->{production_name} eq $organism) {
@@ -149,20 +149,20 @@ sub get_datasets {
   return \@datasets;
 }
 
-sub transform_bool {
+sub transform_bools {
   my ($dataset) = @_;
 
   for my $run ($dataset) {
-    if ($run->isStrandSpecific) {
-      $run->isStrandSpecific = 1;
+    if ($run->{isStrandSpecific}) {
+      $run->{isStrandSpecific} = 1;
     } else {
-      $run->isStrandSpecific = 0;
+      $run->{isStrandSpecific} = 0;
     }
 
-    if ($run->trim_reads) {
-      $run->trim_reads = 1;
+    if ($run->{trim_reads}) {
+      $run->{trim_reads} = 1;
     } else {
-      $run->trim_reads = 0;
+      $run->{trim_reads} = 0;
     }
   }
 }

--- a/lib/perl/Bio/EnsEMBL/EGPipeline/BRC4Aligner/InferStrandness.pm
+++ b/lib/perl/Bio/EnsEMBL/EGPipeline/BRC4Aligner/InferStrandness.pm
@@ -32,10 +32,11 @@ sub param_defaults {
   my ($self) = @_;
   
   return {
-    use_input_if_ambiguous => 0,
+    keep_ambiguous => 0,  # If ambiguous, keep with a flag
+    use_input_if_ambiguous => 0, # Or, use the input if any
     n_samples => 200000,
     infer_max => 0.80,  # Above this, infer stranded
-    infer_min => 0.65,  # Between this and infer_max, don't infer
+    infer_min => 0.65,  # Between this and infer_max, ambiguous
     infer_failed_max => 0.5 # Threshold for max failed reads
   };
 }
@@ -57,7 +58,7 @@ sub run {
   my $res_dir = $self->param_required('results_dir');
   my $log_file = catdir($res_dir, 'log.txt');
   
-  my ($strandness, $is_paired, $no_reads, $output) = $self->get_strandness($bed_file, $sam_file, $n_samples, $input_is_stranded);
+  my ($strandness, $is_paired, $is_ambiguous, $no_reads, $output) = $self->get_strandness($bed_file, $sam_file, $n_samples, $input_is_stranded);
 
   my $is_stranded = 0;
   my $strand_direction = "";
@@ -156,12 +157,12 @@ sub get_strandness {
       die("Inference failed ($exit): $stderr");
     } else {
       my $output = "$stdout\n$stderr";
-      my ($strandness, $is_paired) = $self->parse_inference($stdout, $stderr, $input_is_stranded);
+      my ($strandness, $is_paired, $is_ambiguous) = $self->parse_inference($stdout, $stderr, $input_is_stranded);
       my $no_reads = 0;
       if ($stderr =~ /Total (\d+) usable reads/) {
         $no_reads = $1;
       }
-      return ($strandness, $is_paired, $no_reads, $output);
+      return ($strandness, $is_paired, $is_ambiguous, $no_reads, $output);
     }
   } catch {
     # Nothing could be determined? Return nothing but continue
@@ -187,6 +188,7 @@ sub parse_inference {
   );
 
   my %stats;
+  my $is_ambiguous = 0;
 
   for my $line (split /[\r\n]+/, $text) {
     # Single or paired-end
@@ -241,7 +243,9 @@ sub parse_inference {
     
     # Not enough power to infer: die or use input
     if ($stats{ forward } < $max_ambiguous and not $input_is_stranded) {
-      if ($self->param('use_input_if_ambiguous')) {
+      if ($self->param('keep_ambiguous')) {
+        $is_ambiguous = 1;
+      } elsif ($self->param('use_input_if_ambiguous')) {
         $strandness = '';
       } else {
         die("Ambiguous strand inference: $stats{ forward } < $max_ambiguous:\n$text");
@@ -254,7 +258,9 @@ sub parse_inference {
 
     # Not enough power to infer: use input
     if ($stats{ reverse } < $max_ambiguous and not $input_is_stranded) {
-      if ($self->param('use_input_if_ambiguous')) {
+      if ($self->param('keep_ambiguous')) {
+        $is_ambiguous = 1;
+      } elsif ($self->param('use_input_if_ambiguous')) {
         $strandness = '';
       } else {
         die("Ambiguous strand inference: $stats{ reverse } < $max_ambiguous:\n$text");
@@ -262,7 +268,7 @@ sub parse_inference {
     }
   }
 
-  return ($strandness, $is_paired);
+  return ($strandness, $is_paired, $is_ambiguous);
 }
 
 1;

--- a/lib/perl/Bio/EnsEMBL/EGPipeline/BRC4Aligner/InferStrandness.pm
+++ b/lib/perl/Bio/EnsEMBL/EGPipeline/BRC4Aligner/InferStrandness.pm
@@ -74,6 +74,7 @@ sub run {
   open my $LOG, ">>", $log_file;
 
   print $LOG "Strandness inference: $output\n";
+  print $LOG "Sample = " . $self->param('sample_name');
 
   # Check inferred vs input
   if (defined $input_is_paired and $input_is_paired != $is_paired) {

--- a/lib/perl/Bio/EnsEMBL/EGPipeline/BRC4Aligner/InferStrandness.pm
+++ b/lib/perl/Bio/EnsEMBL/EGPipeline/BRC4Aligner/InferStrandness.pm
@@ -116,7 +116,6 @@ sub run {
       is_stranded => $is_stranded,
       is_paired => $is_paired,
       strand_direction => $strand_direction,
-      strandness => $strandness,
   };
   $self->dataflow_output_id({
       aligner_metadata => $aligner_metadata

--- a/lib/perl/Bio/EnsEMBL/EGPipeline/BRC4Aligner/PrepareFastq.pm
+++ b/lib/perl/Bio/EnsEMBL/EGPipeline/BRC4Aligner/PrepareFastq.pm
@@ -55,6 +55,7 @@ sub run {
   my $sample_data = {
     sample_seq_file_1 => $file1,
     sample_seq_file_2 => $file2,
+    is_paired => $align_meta->{is_paired},
   };
   $self->dataflow_output_id($sample_data, 2);
 }

--- a/lib/perl/Bio/EnsEMBL/EGPipeline/BRC4Aligner/SampleFactory.pm
+++ b/lib/perl/Bio/EnsEMBL/EGPipeline/BRC4Aligner/SampleFactory.pm
@@ -109,20 +109,6 @@ sub run {
       } else {
         $input_metadata{strand_direction} = $default_direction;
       }
-      
-      if ($input_metadata{is_paired}) {
-        if ($input_metadata{strand_direction} eq 'forward') {
-          $input_metadata{strandness} = "FR";
-        } elsif ($input_metadata{strand_direction} eq 'reverse') {
-          $input_metadata{strandness} = "RF";
-        }
-      } else {
-        if ($input_metadata{strand_direction} eq 'forward') {
-          $input_metadata{strandness} = "F";
-        } elsif ($input_metadata{strand_direction} eq 'reverse') {
-          $input_metadata{strandness} = "R";
-        }
-      }
     }
     $sample_data{input_metadata} = \%input_metadata;
     

--- a/lib/perl/Bio/EnsEMBL/EGPipeline/BRC4Aligner/SampleFactory.pm
+++ b/lib/perl/Bio/EnsEMBL/EGPipeline/BRC4Aligner/SampleFactory.pm
@@ -72,7 +72,7 @@ sub run {
     
     my $sample_dir = catdir($results_dir, $dataset->{name}, $sample_name);
     make_path($sample_dir);
-
+    
     my $sample_bam_file = catdir($sample_dir, "results.bam");
     (my $sorted_bam_file = $sample_bam_file) =~ s/\.bam/_name.bam/;
     (my $sample_sam_file = $sample_bam_file) =~ s/\.bam/.sam/;
@@ -115,29 +115,25 @@ sub run {
     # In all cases, output the runs metadata (useful for htseq-count)
     $self->dataflow_output_id(\%sample_data, 3);
     
-    # Don't remake an existing file
-    if (not -s $sorted_bam_file) {
-      
-      # Also check that the sample file (might have a different name) doesn't already exist
-      my $sample_dl_dir = $self->param_required('species_work_dir');
-      my $sample_full_name = $dataset->{name} . "_" . $sample_name;
-      my ($seq1, $seq2) = $self->has_sample_files($sample_dl_dir, $sample_full_name);
-      
-      if ($seq1) {
-        # No need to redownload the files
-        $sample_data{run_seq_files_1} = $seq1 ? [$seq1] : [];
-        $sample_data{run_seq_files_2} = $seq2 ? [$seq2] : [];
-        $self->dataflow_output_id(\%sample_data, 4);
-      } else {
-        for my $run_id (@run_ids) {
-          my %run_data = (
-            run_id => $run_id,
-          );
-          $self->dataflow_output_id(\%run_data, 2);
-        }
-      }
+    # Check that the sample file (might have a different name) doesn't already exist
+    my $sample_dl_dir = $self->param_required('species_work_dir');
+    my $sample_full_name = $dataset->{name} . "_" . $sample_name;
+    my ($seq1, $seq2) = $self->has_sample_files($sample_dl_dir, $sample_full_name);
+    
+    if ($seq1) {
+      # No need to redownload the files
+      $sample_data{run_seq_files_1} = $seq1 ? [$seq1] : [];
+      $sample_data{run_seq_files_2} = $seq2 ? [$seq2] : [];
       $self->dataflow_output_id(\%sample_data, 4);
+    } else {
+      for my $run_id (@run_ids) {
+        my %run_data = (
+          run_id => $run_id,
+        );
+        $self->dataflow_output_id(\%run_data, 2);
+      }
     }
+    $self->dataflow_output_id(\%sample_data, 4);
   }
 }
 

--- a/lib/perl/Bio/EnsEMBL/EGPipeline/Common/Aligner/HISAT2Aligner.pm
+++ b/lib/perl/Bio/EnsEMBL/EGPipeline/Common/Aligner/HISAT2Aligner.pm
@@ -36,13 +36,14 @@ sub new {
   (
     $self->{max_intron_length},
     $self->{gtf_file},
-    $self->{strandness},
+    $self->{strand_direction},
+    $self->{is_paired},
     $self->{no_spliced},
     $self->{number_primary},
   ) =
   rearrange(
     [
-      'MAX_INTRON_LENGTH', 'GTF_FILE', 'STRANDNESS', 'NO_SPLICED', 'NUMBER_PRIMARY'
+      'MAX_INTRON_LENGTH', 'GTF_FILE', 'STRAND_DIRECTION', 'IS_PAIRED', 'NO_SPLICED', 'NUMBER_PRIMARY'
     ], @args
   );
   
@@ -59,16 +60,24 @@ sub new {
     $self->{align_params} .= " --max-intronlen $self->{max_intron_length} ";
   }
 
-  if ($self->{strandness}) {
-    my $st = $self->{strandness};
-
-    if ($st) {
-      if ($st =~ /^(F|R|FR|RF)$/) {
-        $self->{align_params} .= " --rna-strandness $st";
+  if ($self->{strand_direction}) {
+    $strandness = "";
+    if ($self->{strand_direction} eq 'forward') {
+      if ($self->{is_paired}) {
+        $strandness = "FR";
       } else {
-        die "Unrecognized strandness: $st (needs to be F, R, FR, RF, or null)";
+        $strandness = "F";
       }
+    } elsif ($self->{strand_direction} eq 'reverse') {
+      if ($self->{is_paired}) {
+        $strandness = "RF";
+      } else {
+        $standness = "R";
+      }
+    } else {
+      die "Unsupported strand_direction: " . $self->{strand_direction};
     }
+    $self->{align_params} .= " --rna-strandness $strandness";
   }
 
   if ($self->{no_spliced}) {

--- a/lib/perl/Bio/EnsEMBL/EGPipeline/Common/Aligner/HISAT2Aligner.pm
+++ b/lib/perl/Bio/EnsEMBL/EGPipeline/Common/Aligner/HISAT2Aligner.pm
@@ -61,7 +61,7 @@ sub new {
   }
 
   if ($self->{strand_direction}) {
-    $strandness = "";
+    my $strandness = "";
     if ($self->{strand_direction} eq 'forward') {
       if ($self->{is_paired}) {
         $strandness = "FR";
@@ -72,7 +72,7 @@ sub new {
       if ($self->{is_paired}) {
         $strandness = "RF";
       } else {
-        $standness = "R";
+        $strandness = "R";
       }
     } else {
       die "Unsupported strand_direction: " . $self->{strand_direction};

--- a/lib/perl/Bio/EnsEMBL/EGPipeline/PipeConfig/SRAAlignment_BRC4_conf.pm
+++ b/lib/perl/Bio/EnsEMBL/EGPipeline/PipeConfig/SRAAlignment_BRC4_conf.pm
@@ -1554,7 +1554,7 @@ sub pipeline_analyses {
         aligner_metadata => '#aggregated_aligner_metadata#',
         threads       => $self->o('threads'),
       },
-      -rc_name           => '16GB_multicpu',
+      -rc_name           => '64GB_multicpu',
       -failed_job_tolerance => 100,
       -flow_into         => {
                                '2' => 'SamToBam',

--- a/lib/perl/Bio/EnsEMBL/EGPipeline/PipeConfig/SRAAlignment_BRC4_conf.pm
+++ b/lib/perl/Bio/EnsEMBL/EGPipeline/PipeConfig/SRAAlignment_BRC4_conf.pm
@@ -348,6 +348,8 @@ If this is expected, simply rerun the failing job by adding the following parame
 
   ignore_single_paired = 1
 
+(NB: this is now the default)
+
 =item Force a consensus
 
 If for example there are mixed stranded/unstranded samples in a dataset, you can force all the
@@ -632,6 +634,8 @@ sub default_options {
 
     # Use input metadata, instead of inferring them (pair/strand)
     infer_metadata => 1,
+    # When aggregating samples for a dataset, don't mind if it's a mix of paired-end/single-end
+    ignore_single_paired => 1,
 
     # For heavy analyses, use multiple cpus
     threads    => 4,
@@ -1089,6 +1093,9 @@ sub pipeline_analyses {
     {
       -logic_name        => 'Aggregate_metadata',
       -module            => 'Bio::EnsEMBL::EGPipeline::BRC4Aligner::AggregateMetadata',
+      -parameters        => {
+        ignore_single_paired => $self->o('ignore_single_paired'),
+      },
       -failed_job_tolerance => 100,
       -analysis_capacity => 1,
       -max_retry_count => 0,

--- a/lib/perl/Bio/EnsEMBL/EGPipeline/PipeConfig/SRAAlignment_BRC4_conf.pm
+++ b/lib/perl/Bio/EnsEMBL/EGPipeline/PipeConfig/SRAAlignment_BRC4_conf.pm
@@ -1901,13 +1901,14 @@ sub pipeline_analyses {
 sub resource_classes {
   my ($self) = @_;
 
+  my %resources = %{$self->SUPER::resource_classes};
+
+  # Add resources for highly demanding processes
   my $queue = $self->o('queue_name');
   my @mems = (8, 16, 32, 64);
   my $tmem = 4;
-  my $time = "24:00:00";
+  my $time = "240:00:00";   # 10 days
   my $threads = $self->o("threads");
-
-  my %resources = %{$self->SUPER::resource_classes};
 
   for my $mem (@mems) {
     my $name = "${mem}GB_multicpu";

--- a/lib/perl/Bio/EnsEMBL/ENA/SRA/BaseSraAdaptor.pm
+++ b/lib/perl/Bio/EnsEMBL/ENA/SRA/BaseSraAdaptor.pm
@@ -55,7 +55,7 @@ my $logger = get_logger();
 
 our @EXPORT = qw(get_adaptor taxonomy_adaptor get_linked_objects);
 
-my $url = 'https://www.ebi.ac.uk/ena/browser/api/xml/%s';
+my $url = 'https://www.ebi.ac.uk/ena/browser/api/xml/%s?includeLinks=true';
 
 my $adaptor_classes = {
     'experiment' => 'Bio::EnsEMBL::ENA::SRA::ExperimentAdaptor',
@@ -178,6 +178,7 @@ sub get_by_accession_and_type {
         if ( !defined $obj ) {
 
 	    $logger->debug("Getting object using url " . sprintf( $url, $acc ));
+	    warn("Getting object using url " . sprintf( $url, $acc ));
 
             my $doc = $self->get_document( sprintf( $url, $acc ) );
             if(!$doc->{$key}) {

--- a/lib/perl/Bio/EnsEMBL/ENA/SRA/BaseSraAdaptor.pm
+++ b/lib/perl/Bio/EnsEMBL/ENA/SRA/BaseSraAdaptor.pm
@@ -178,7 +178,6 @@ sub get_by_accession_and_type {
         if ( !defined $obj ) {
 
 	    $logger->debug("Getting object using url " . sprintf( $url, $acc ));
-	    warn("Getting object using url " . sprintf( $url, $acc ));
 
             my $doc = $self->get_document( sprintf( $url, $acc ) );
             if(!$doc->{$key}) {

--- a/lib/perl/Bio/EnsEMBL/ENA/SRA/FileAdaptor.pm
+++ b/lib/perl/Bio/EnsEMBL/ENA/SRA/FileAdaptor.pm
@@ -48,11 +48,22 @@ my $logger = get_logger();
 
 sub get_by_accession {
   my ($self, $url, $acc) = @_;
-
+  
   # As in the Experiment (or Run) xml the links are not correct, we correct here
   # Means it is now hardcoded, not ideal, but at least it is working
-
-  $url = "https://www.ebi.ac.uk/ena/portal/api/filereport?accession=$acc&result=read_run";
+  my @fields = qw(
+    run_accession
+    fastq_ftp
+    fastq_md5
+    fastq_bytes
+    library_layout
+    secondary_study_accession
+    secondary_sample_accession
+    experiment_accession
+    run_accession
+  );
+  my $fields_str = join(",", @fields);
+  $url = "https://www.ebi.ac.uk/ena/portal/api/filereport?accession=$acc&result=read_run&fields=$fields_str";
   
   $logger->info("Get read files by accession, $acc, using url, '$url'...");
 


### PR DESCRIPTION
- Don't keep "strandness": this value is only needed by hisat2, and it can be reconstructed with "strand_direction" and "is_paired".
- Add ambiguity and ambiguity rule: if an inferrence is too weak, set it as ambiguous. Then aggregate can work as long as there is a consensus with the remaining samples, and if the proportion of ambiguous samples is not too high.
- Also fix SRA retrieval (updates to the API)
- Change some params: allow mixed paired/single datasets by default, increase high demand jobs resources...
- Fix a few things