### PR TITLE
Mbarba/transfer xrefs

### DIFF
--- a/scripts/brc4/transfer_versions.pl
+++ b/scripts/brc4/transfer_versions.pl
@@ -462,8 +462,6 @@ sub update_xrefs {
   my $new_count = 0;
 
   my $aa = $registry->get_adaptor($species, "core", 'analysis');
-  my $analysis = $aa->fetch_by_logic_name('brc4_community_annotation');
-  
   
   my $ga = $registry->get_adaptor($species, "core", 'gene');
   my $xa = $registry->get_adaptor($species, "core", 'DBentry');
@@ -483,9 +481,13 @@ sub update_xrefs {
     for my $xref (@$old_xrefs) {
       my $dbname = $xref->dbname;
       # We only include dbnames that we expect
-      next if not exists $ok_xrefs{$dbname};
+      if (not exists $ok_xrefs{$dbname}) {
+        $logger->debug("NO TRANSFER for gene $id xref:\t$dbname\twith ID " . $xref->primary_id);
+        next;
+      }
       # Rename the dbname in case we need to transfer old xrefs which had their name changed
       $dbname = $ok_xrefs{$dbname};
+      $xref->dbname($dbname);
       if (not exists $xref_dict{$dbname}) {
         $logger->debug("Transfer gene $id xref: $dbname with ID " . $xref->primary_id);
         $update_count++;

--- a/scripts/brc4/transfer_versions.pl
+++ b/scripts/brc4/transfer_versions.pl
@@ -461,6 +461,7 @@ sub update_xrefs {
   my $update_count = 0;
   my $new_count = 0;
   my %no_transfer = ();
+  my %yes_transfer = ();
 
   my $aa = $registry->get_adaptor($species, "core", 'analysis');
   
@@ -491,6 +492,7 @@ sub update_xrefs {
       $dbname = $ok_xrefs{$dbname};
       $xref->dbname($dbname);
       if (not exists $xref_dict{$dbname}) {
+        $yes_transfer{$dbname}++;
         $logger->debug("Transfer gene $id xref: $dbname with ID " . $xref->primary_id);
         $update_count++;
         if ($update) {
@@ -506,6 +508,10 @@ sub update_xrefs {
   
   $logger->info("$update_count gene xrefs transferred");
   $logger->info("$new_count new genes, without xref to transfer");
+  for my $dbname (sort keys %yes_transfer) {
+    my $count = $yes_transfer{$dbname};
+    $logger->info("Transfered: $count from external_db '$dbname'");
+  }
   for my $dbname (sort keys %no_transfer) {
     my $count = $no_transfer{$dbname};
     $logger->info("NOT transfered: $count from external_db '$dbname'");

--- a/scripts/brc4/transfer_versions.pl
+++ b/scripts/brc4/transfer_versions.pl
@@ -457,15 +457,21 @@ sub update_xrefs {
       $new_count++;
       next;
     }
+    my $xrefs = $gene->get_all_DBEntries();
+    my %xref_dict = map { $_->dbname => $_ } @$xrefs;
+
     my $old_xrefs = $old_gene->{xrefs};
 
-    if ($update) {
-      for my $xref (@$old_xrefs) {
-        $logger->debug("Transfer gene $id xref: $xref");
-        $xa->store($xref, $gene->dbID, 'Gene');
+    use Data::Dumper;
+    for my $xref (@$old_xrefs) {
+      if (not exists $xref_dict{$xref->dbname}) {
+        $logger->debug("Transfer gene $id xref: " . $xref->dbname . " with ID " . $xref->primary_id);
+        $update_count++;
+        if ($update) {
+          $xa->store($xref, $gene->dbID, 'Gene');
+        }
       }
     }
-    $update_count += scalar(@$old_xrefs);
   }
   
   $logger->info("$update_count gene xrefs transferred");

--- a/scripts/brc4/transfer_versions.pl
+++ b/scripts/brc4/transfer_versions.pl
@@ -460,6 +460,10 @@ sub update_xrefs {
   
   my $update_count = 0;
   my $new_count = 0;
+
+  my $aa = $registry->get_adaptor($species, "core", 'analysis');
+  my $analysis = $aa->fetch_by_logic_name('brc4_community_annotation');
+  
   
   my $ga = $registry->get_adaptor($species, "core", 'gene');
   my $xa = $registry->get_adaptor($species, "core", 'DBentry');
@@ -486,7 +490,11 @@ sub update_xrefs {
         $logger->debug("Transfer gene $id xref: $dbname with ID " . $xref->primary_id);
         $update_count++;
         if ($update) {
-          $xa->store($xref, $gene->dbID, 'Gene');
+          # Ensure we use an up to date analysis
+          my $analysis_name = $xref->analysis->logic_name;
+          my $analysis = $aa->fetch_by_logic_name($analysis_name);
+          $xref->analysis($analysis);
+          $xa->store($xref, $gene->dbID, 'Gene', 1); # ignore release
         }
       }
     }

--- a/scripts/brc4/transfer_versions.pl
+++ b/scripts/brc4/transfer_versions.pl
@@ -460,6 +460,7 @@ sub update_xrefs {
   
   my $update_count = 0;
   my $new_count = 0;
+  my %no_transfer = ();
 
   my $aa = $registry->get_adaptor($species, "core", 'analysis');
   
@@ -483,6 +484,7 @@ sub update_xrefs {
       # We only include dbnames that we expect
       if (not exists $ok_xrefs{$dbname}) {
         $logger->debug("NO TRANSFER for gene $id xref:\t$dbname\twith ID " . $xref->primary_id);
+        $no_transfer{$dbname}++;
         next;
       }
       # Rename the dbname in case we need to transfer old xrefs which had their name changed
@@ -504,6 +506,10 @@ sub update_xrefs {
   
   $logger->info("$update_count gene xrefs transferred");
   $logger->info("$new_count new genes, without xref to transfer");
+  for my $dbname (sort keys %no_transfer) {
+    my $count = $no_transfer{$dbname};
+    $logger->info("NOT transfered: $count from external_db '$dbname'");
+  }
   $logger->info("(Use --write to update the descriptions in the database)") if $update_count > 0 and not $update;
 }
 

--- a/scripts/brc4/transfer_versions.pl
+++ b/scripts/brc4/transfer_versions.pl
@@ -462,6 +462,7 @@ sub update_xrefs {
   my $new_count = 0;
   my %no_transfer = ();
   my %yes_transfer = ();
+  my $total_transfer = 0;
 
   my $aa = $registry->get_adaptor($species, "core", 'analysis');
   
@@ -501,6 +502,7 @@ sub update_xrefs {
           my $analysis = $aa->fetch_by_logic_name($analysis_name);
           $xref->analysis($analysis);
           $xa->store($xref, $gene->dbID, 'Gene', 1); # ignore release
+          $total_transfer++;
         }
       }
     }
@@ -510,13 +512,20 @@ sub update_xrefs {
   $logger->info("$new_count new genes, without xref to transfer");
   for my $dbname (sort keys %yes_transfer) {
     my $count = $yes_transfer{$dbname};
-    $logger->info("Transfered: $count from external_db '$dbname'");
+    $logger->info("Transfered: $count\t$dbname");
   }
   for my $dbname (sort keys %no_transfer) {
     my $count = $no_transfer{$dbname};
     $logger->info("NOT transfered: $count from external_db '$dbname'");
   }
-  $logger->info("(Use --write to update the descriptions in the database)") if $update_count > 0 and not $update;
+  $logger->info("$total_transfer written xref transfers") if $total_transfer > 0;
+  if ($update_count > 0) {
+    if (not $update) {
+      $logger->info("(Use --write to update the xrefs in the database)");
+    }
+  } else {
+    $logger->info("(No xrefs to update in the database)");
+  }
 }
 
 sub add_events {


### PR DESCRIPTION
We can already transfer a description (and update the gene version) from an old database, this PR adds the ability to transfer xrefs as well.
It only transfers xrefs that do not already exist for a given external_db name.
It also uses a strict list of acceptable db names (can be updated if we find other xrefs we want to transfer): it starts with PUBMED, EntrezGene, RefSeq_gene_name, and BRC4_Community_Annotation.
Add VB_Community_Annotation as an alias to BRC4_Community_Annotation.