### PR TITLE
Mbarba/fix paired

### DIFF
--- a/lib/perl/Bio/EnsEMBL/EGPipeline/BRC4Aligner/ExtractJunction.pm
+++ b/lib/perl/Bio/EnsEMBL/EGPipeline/BRC4Aligner/ExtractJunction.pm
@@ -32,9 +32,6 @@ sub run {
   
   my $bam_file = $self->param_required('bam_file');
   my $aligner_metadata = $self->param_required('aligner_metadata');
-  my $is_paired = $aligner_metadata->{'is_paired'};
-  my $is_stranded = $aligner_metadata->{'is_stranded'};
-  my $strand_direction = $aligner_metadata->{'strand_direction'};
 
   # Junction file
   my $bam_results_dir = $self->param_required('results_dir');

--- a/lib/perl/Bio/EnsEMBL/EGPipeline/BRC4Aligner/OrderBam.pm
+++ b/lib/perl/Bio/EnsEMBL/EGPipeline/BRC4Aligner/OrderBam.pm
@@ -37,7 +37,7 @@ sub write_output {
   my $input_bam = $self->param_required('input_bam');
   my $sorted_bam = $self->param_required('sorted_bam');
   my $aligner_metadata = $self->param_required('aligner_metadata');
-  my $is_paired = $aligner_metadata->{'is_paired'};
+  my $is_paired = $self->param_required('is_paired');
 
   # Filter out unmapped reads or pairs
   my $filter = "";

--- a/lib/perl/Bio/EnsEMBL/EGPipeline/BRC4Aligner/SplitReadStrand.pm
+++ b/lib/perl/Bio/EnsEMBL/EGPipeline/BRC4Aligner/SplitReadStrand.pm
@@ -32,7 +32,7 @@ sub run {
   
   my $bam_file = $self->param_required('bam_file');
   my $aligner_metadata = $self->param_required('aligner_metadata');
-  my $is_paired = $aligner_metadata->{'is_paired'} // $self->param{'is_paired'};
+  my $is_paired = $self->param_required('is_paired');
   my $is_stranded = $aligner_metadata->{'is_stranded'};
   my $strand_direction = $aligner_metadata->{'strand_direction'};
 

--- a/lib/perl/Bio/EnsEMBL/EGPipeline/BRC4Aligner/SplitReadStrand.pm
+++ b/lib/perl/Bio/EnsEMBL/EGPipeline/BRC4Aligner/SplitReadStrand.pm
@@ -58,7 +58,7 @@ sub run {
     }
 
     # Store align commands
-    for my $cmd ($cmds) {
+    for my $cmd (@$cmds) {
       print("Store command $cmd\n");
       my $align_cmd = {
         cmds => $cmd,

--- a/lib/perl/Bio/EnsEMBL/EGPipeline/BRC4Aligner/SplitReadStrand.pm
+++ b/lib/perl/Bio/EnsEMBL/EGPipeline/BRC4Aligner/SplitReadStrand.pm
@@ -32,7 +32,7 @@ sub run {
   
   my $bam_file = $self->param_required('bam_file');
   my $aligner_metadata = $self->param_required('aligner_metadata');
-  my $is_paired = $aligner_metadata->{'is_paired'};
+  my $is_paired = $aligner_metadata->{'is_paired'} // $self->param{'is_paired'};
   my $is_stranded = $aligner_metadata->{'is_stranded'};
   my $strand_direction = $aligner_metadata->{'strand_direction'};
 

--- a/lib/perl/Bio/EnsEMBL/EGPipeline/BRC4Aligner/SplitReadStrand.pm
+++ b/lib/perl/Bio/EnsEMBL/EGPipeline/BRC4Aligner/SplitReadStrand.pm
@@ -58,11 +58,14 @@ sub run {
     }
 
     # Store align commands
-      my $align_cmds = {
-        cmds => $cmds,
+    for my $cmd ($cmds) {
+      print("Store command $cmd\n");
+      my $align_cmd = {
+        cmds => $cmd,
         sample_name => $self->param('sample_name'),
       };
-      $self->store_align_cmds($align_cmds);
+      $self->store_align_cmds($align_cmd);
+    }
 
   } else {
     print("The reads are not strand-specific: skip splitting");

--- a/lib/perl/Bio/EnsEMBL/EGPipeline/BRC4Aligner/WriteMetadata.pm
+++ b/lib/perl/Bio/EnsEMBL/EGPipeline/BRC4Aligner/WriteMetadata.pm
@@ -49,10 +49,7 @@ sub write_output {
   }
   if (defined $is_stranded) {
     $metadata{isStrandSpecific} = $is_stranded ? JSON::true : JSON::false;
-
-    if ($self->param('is_stranded')) {
-      $metadata{strandDirection} = $strand_direction;
-    }
+    $metadata{strandDirection} = $strand_direction;
   }
   if (defined $self->param("dnaseq")) {
     $metadata{dnaseq} = $self->param('dnaseq') ? JSON::true : JSON::false;


### PR DESCRIPTION
Fix a bug for the bam files for runs that are both paired-end and stranded: the paired flag was not properly handled by the bam strand split module (SplitReadStrand), resulting in bed files without the correct direction (looking roughly the same as unstranded).

Fix others calls to this flag that have less impact (OrderBam).

Minor fixes:
- correct list of commands from the splits (instead of an array ref)
- Add strandDirection to the metadata file correctly