### PR TITLE
Remove queues for slurm to schedule itself

### DIFF
--- a/lib/perl/Bio/EnsEMBL/EGPipeline/PipeConfig/EGGeneric_conf.pm
+++ b/lib/perl/Bio/EnsEMBL/EGPipeline/PipeConfig/EGGeneric_conf.pm
@@ -160,6 +160,12 @@ sub _slurm_resource {
   my $queue = $conf->{queue};
   my $time = $conf->{time};
 
+  # Remove queues if they are not special so that Slurm can schedule the right queue itself
+  my %special_queue = map { $_ => 1 } qw(datamover debug gpu short_gpu);
+  if (not exists $special_queue{$queue}) {
+    $queue = undef;
+  }
+
   # Prepare memory string
   my $rmem;
   if ($mem) {


### PR DESCRIPTION
Allow the Slurm scheduler to decide the partition/queue by removing the partition from the requested resources, unless the requested partition is special (like datamover).