### PR TITLE
Check for empty count files

### DIFF
--- a/lib/perl/Bio/EnsEMBL/EGPipeline/BRC4Aligner/HtseqCountName.pm
+++ b/lib/perl/Bio/EnsEMBL/EGPipeline/BRC4Aligner/HtseqCountName.pm
@@ -171,6 +171,10 @@ sub run_htseq_count {
     }
   }
 
+  if (not -s $htseq_file) {
+    die("Generated htseq-count file is empty: $htseq_file");
+  }
+
   return $cmd;
 }
 


### PR DESCRIPTION
There has been some cases where the htseq-count files generated are empty (the files should never be empty, even if there was no data to count).

The module now dies if the output file is empty.