### PR TITLE
throw an error if we have an orgr_abbrev repeated in vb-p

### DIFF
--- a/scripts/brc4/brc4_species.pl
+++ b/scripts/brc4/brc4_species.pl
@@ -114,8 +114,7 @@ sub usage {
     Create a list of all species metadata in BRC4 prod.
 
     --registry <path> : Ensembl registry
-    
-    
+
     --help            : show this help message
     --verbose         : show detailed progress
     --debug           : show even more information (for debugging purposes)

--- a/scripts/brc4/brc4_species.pl
+++ b/scripts/brc4/brc4_species.pl
@@ -98,7 +98,7 @@ for my $genome (sort {
 # Return the value for all the keys
 sub get_meta_value {
   my ($meta, $key) = @_;
-  my ($value) =@{ $meta->list_value_by_key($key) };
+  my ($value) = @{ $meta->list_value_by_key($key) };
   return $value;
 }
 

--- a/scripts/brc4/brc4_species.pl
+++ b/scripts/brc4/brc4_species.pl
@@ -80,7 +80,7 @@ for my $genome (sort {
     $a->{'BRC4.component'} cmp $b->{'BRC4.component'}
       or $a->{'species.scientific_name'} cmp $b->{'species.scientific_name'}
       or $a->{'BRC4.organism_abbrev'} cmp $b->{'BRC4.organism_abbrev'}
-  } @genomes){
+  } @genomes) {
   # Check if BRC4.organism_abbrev is unique
   my $abbrev = $genome->{'BRC4.organism_abbrev'};
   my $prod_name = $genome->{'species.scientific_name'};

--- a/scripts/brc4/brc4_species.pl
+++ b/scripts/brc4/brc4_species.pl
@@ -118,7 +118,6 @@ sub usage {
     Create a list of all species metadata in BRC4 prod.
 
     --registry <path> : Ensembl registry
-
     --help            : show this help message
     --verbose         : show detailed progress
     --debug           : show even more information (for debugging purposes)

--- a/scripts/brc4/brc4_species.pl
+++ b/scripts/brc4/brc4_species.pl
@@ -97,7 +97,7 @@ for my $genome (sort {
     die "Error: Organism abbreviation missing for $prod_name\n";
   }
   say join("\t", map { $genome->{$_} // "" } @fields);
-  }
+}
 
 # Return the value for all the keys
 sub get_meta_value {

--- a/scripts/brc4/brc4_species.pl
+++ b/scripts/brc4/brc4_species.pl
@@ -85,12 +85,16 @@ for my $genome (sort {
   my $abbrev = $genome->{'BRC4.organism_abbrev'};
   my $prod_name = $genome->{'species.scientific_name'};
 
-  if (defined $abbrev && !$unique_abbrevs{$abbrev}) {
-      # BRC4.organism_abbrev is unique
-      $unique_abbrevs{$abbrev}=$prod_name;
+  if (defined $abbrev) {
+    if (! $unique_abbrevs{$abbrev}) {
+      $unique_abbrevs{$abbrev} = $prod_name;
+    }
+    else {
+      die "Error: Non-unique abbreviation encountered for $prod_name: $abbrev\n";
+    }
   }
-  else{
-    die "Error: Non-unique abbreviation encountered: $abbrev $prod_name\n";
+  else {
+    die "Error: Organism abbreviation missing for $prod_name\n";
   }
   say join("\t", map { $genome->{$_} // "" } @fields);
   }


### PR DESCRIPTION
I have modifies the brc4_species.pl file to die if there is a repeated org_abbrev as we always want to keep unique abbrevs for brc4. This flags if we have any redundant species in vbp.