### PR TITLE
Handle missing libs_dir argument gracefully

### DIFF
--- a/scripts/brc4/repeat_tab_to_list.pl
+++ b/scripts/brc4/repeat_tab_to_list.pl
@@ -228,6 +228,7 @@ sub opt_check {
   usage("tab file needed") if not $opt{tab};
   usage("registry needed") if not $opt{registry};
   usage("ref_registry needed") if not $opt{ref_registry};
+  usage("libs_dir needed") if not $opt{libs_dir};
   usage()                if $opt{help};
   Log::Log4perl->easy_init($INFO) if $opt{verbose};
   Log::Log4perl->easy_init($DEBUG) if $opt{debug};


### PR DESCRIPTION
`libs_dir` is a required argument and if not passed, an error is raised when trying to access the directory. Added it to the list of required arguments, triggering a usage message when missing.