### PR TITLE
Warn, not die, to show all errors

### DIFF
--- a/scripts/brc4/brc4_species.pl
+++ b/scripts/brc4/brc4_species.pl
@@ -90,11 +90,11 @@ for my $genome (sort {
       $unique_abbrevs{$abbrev} = $prod_name;
     }
     else {
-      die "Error: Non-unique abbreviation encountered for $prod_name: $abbrev\n";
+      warn "Error: Non-unique abbreviation encountered for $prod_name: $abbrev\n";
     }
   }
   else {
-    die "Error: Organism abbreviation missing for $prod_name\n";
+    warn "Error: Organism abbreviation missing for $prod_name\n";
   }
   say join("\t", map { $genome->{$_} // "" } @fields);
 }


### PR DESCRIPTION
If there is more than one abbrev error, then we need to continue instead of dying at the first occurrence.