### PR TITLE
Download runs in dataset subdirs

### DIFF
--- a/lib/perl/Bio/EnsEMBL/EGPipeline/PipeConfig/SRAAlignment_BRC4_conf.pm
+++ b/lib/perl/Bio/EnsEMBL/EGPipeline/PipeConfig/SRAAlignment_BRC4_conf.pm
@@ -1308,7 +1308,7 @@ sub pipeline_analyses {
       -max_retry_count => 3,
       -failed_job_tolerance => 10,
       -parameters        => {
-        work_dir => '#species_work_dir#',
+        work_dir => '#species_work_dir#/#expr(#dataset_metadata#->{name})expr#',
         fallback_ncbi => $self->o('fallback_ncbi'),
       },
       -rc_name           => 'normal',


### PR DESCRIPTION
Prevent issues when the same run is used by several datasets for the same species.

The sample names already have the dataset as a prefix, but the temporary run files did not, leading to problems when 2 datasets in the same species were downloading the same file at the same time. This fix isolates the run files per dataset to avoid any such conflicts.