### PR TITLE
Remove orphan object_xrefs after removing transcripts

### DIFF
--- a/scripts/brc4/delete_genes.pl
+++ b/scripts/brc4/delete_genes.pl
@@ -66,6 +66,14 @@ sub delete_genes {
     }
   }
   
+  # Aftermath: remove dangling object_xrefs, ontology_xrefs, dependent_xrefs
+  if ($update) {
+    my $dbc = $ga->dbc;
+    $dbc->do("DELETE object_xref FROM object_xref LEFT JOIN transcript ON ensembl_id=transcript_id WHERE ensembl_object_type=\"transcript\" AND ensembl_id IS NOT NULL AND transcript_id IS NULL;");
+    $dbc->do("DELETE ontology_xref FROM ontology_xref LEFT JOIN object_xref USING(object_xref_id) WHERE ensembl_id IS NULL;");
+    $dbc->do("DELETE dependent_xref FROM dependent_xref LEFT JOIN object_xref USING(object_xref_id) WHERE ensembl_id IS NULL;");
+  }
+  
   print STDERR "$delete_count genes deleted\n";
   print STDERR "(Use --update to make the changes to the database)\n" if $delete_count == 0 and @$list > 0;
 }


### PR DESCRIPTION
The API doesn't clean up the object_xrefs and other dependent xrefs after deleting transcripts. This adds a few cleanup queries.