### PR TITLE
fixing LoadAlignmentXref hits versions parsing

### DIFF
--- a/lib/perl/Bio/EnsEMBL/EGPipeline/Xref/LoadAlignmentXref.pm
+++ b/lib/perl/Bio/EnsEMBL/EGPipeline/Xref/LoadAlignmentXref.pm
@@ -275,7 +275,11 @@ sub xref_metadata {
   my @headers = $fasta =~ /^>(.*)/gm;
   foreach my $header (@headers) {
     my ($accession, $meta_data) = $header =~ /^(\S+)\s+(.*)/;
-    my ($display_id, $desc, $version) = split(/\|/, $meta_data);
+    # sometimes descriptions can have '|' in them
+    my ($display_id, @desc_version) = split(/\|/, $meta_data);
+    # thus getting versions from the tail of the list
+    my $version = pop @desc_version;
+    my $desc = join("|", @desc_version);
     
     if (defined $desc && $desc ne '') {
       if ($desc =~ /^($blacklist)$/) {


### PR DESCRIPTION
fixing version parsing for entries with complicated metadata like
```
>A0A0C9RL41 A0A0C9RL41|ORF c21843_g9_i1|g.38233 c21843_g9_i1|m.382 33 type:internal len:180 (+) protein (Fragment)|1
```